### PR TITLE
feat: add followers queue and settings popup

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -1,5 +1,155 @@
-body { font-family: sans-serif; padding: 10px; width: 250px; }
-h1 { font-size: 16px; margin: 0 0 8px; }
-input { width: 100%; margin-bottom: 8px; }
-button { margin-right: 6px; }
-pre { font-size: 11px; color: #555; white-space: pre-wrap; }
+body {
+  width: 380px;
+  background: #1f1f1f;
+  color: #f1f1f1;
+  font-family: system-ui, sans-serif;
+  margin: 0;
+}
+
+#topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  background: #222;
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  color: #f1f1f1;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.tab-btn.active {
+  border-bottom: 2px solid #e02424;
+}
+
+.card {
+  background: #2a2a2a;
+  border-radius: 4px;
+  padding: 8px;
+  margin: 8px 0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+button {
+  background: #e02424;
+  border: none;
+  color: #fff;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #ff3b30;
+}
+
+#followersTable {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#followersTable th,
+#followersTable td {
+  padding: 4px;
+}
+
+#followersTable tr:nth-child(even) {
+  background: #333;
+}
+
+#pagination {
+  text-align: center;
+  margin-top: 4px;
+}
+
+#pagination button {
+  margin: 0 2px;
+  background: #444;
+}
+
+#footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px;
+  background: #222;
+}
+
+.dropdown {
+  position: relative;
+}
+
+.dropdown-menu {
+  display: none;
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  background: #2a2a2a;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  z-index: 10;
+}
+
+.dropdown-menu button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  padding: 8px;
+  border: none;
+  color: #f1f1f1;
+}
+
+.dropdown-menu button:hover {
+  background: #444;
+}
+
+#toast {
+  position: fixed;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  padding: 6px 12px;
+  border-radius: 4px;
+  display: none;
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+#runControls button {
+  margin-right: 4px;
+}
+
+label {
+  display: block;
+  margin: 4px 0;
+}
+
+input[type="number"] {
+  width: 60px;
+}
+
+input[type="range"] {
+  vertical-align: middle;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #555;
+}
+
+#followersTable td:first-child {
+  width: 40px;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,18 +1,115 @@
 <!doctype html>
 <html>
-<head>
-  <meta charset="utf-8" />
-  <title>IG Silent Bot</title>
-  <link rel="stylesheet" href="popup.css">
-</head>
-<body>
-  <h1>IG Silent Bot</h1>
-  <input id="username" placeholder="username">
-  <button id="follow">Seguir</button>
-  <button id="like">Curtir última</button>
-  <button id="start">Rodar fila</button>
-  <button id="stop">Parar</button>
-  <pre id="log"></pre>
-  <script src="popup.js"></script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>IG Silent Bot</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <div id="topbar">
+      <div id="tabs">
+        <button class="tab-btn active" data-tab="queue">Fila de Contas</button>
+        <button class="tab-btn" data-tab="config">Configurações</button>
+      </div>
+      <div id="currentUser"></div>
+    </div>
+
+    <div id="queue" class="tab-content active">
+      <div id="runControls" class="card">
+        <button id="start">Iniciar</button>
+        <button id="stop">Parar</button>
+      </div>
+
+      <div id="actionSelect" class="card">
+        <label><input type="radio" name="mode" value="follow" /> Seguir</label>
+        <label
+          ><input type="radio" name="mode" value="follow-like" /> Seguir +
+          Curtir <input id="likeCount" type="number" min="1" max="3" value="1"
+        /></label>
+        <label
+          ><input type="radio" name="mode" value="unfollow" /> Deixar de
+          seguir</label
+        >
+      </div>
+
+      <div id="followersContainer" class="card">
+        <table id="followersTable">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Usuário</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <div id="pagination"></div>
+      </div>
+    </div>
+
+    <div id="config" class="tab-content">
+      <div class="card">
+        <label
+          >Aguardar <input id="cfgActionDelay" type="number" min="0" /> segundos
+          após seguir/deixar de seguir/curtir</label
+        >
+        <label
+          >Aguardar <input id="cfgSkipDelay" type="number" min="0" /> segundos
+          após pular</label
+        >
+        <label
+          >Tempo de espera aleatório de até
+          <input id="cfgRandomPercent" type="range" min="0" max="100" />%</label
+        >
+      </div>
+      <div class="card">
+        <label
+          >Tente novamente
+          <input id="cfgRetrySoft" type="number" min="0" /> minutos após limite
+          suave de taxa</label
+        >
+        <label
+          >Tente novamente
+          <input id="cfgRetryHard" type="number" min="0" /> horas após limite
+          rígido</label
+        >
+        <label
+          >Tente novamente
+          <input id="cfgRetry429" type="number" min="0" /> minutos após limite
+          de taxa 429</label
+        >
+      </div>
+      <div class="card">
+        <label
+          ><input id="cfgKeepFollowers" type="checkbox" /> Não deixar de seguir
+          pessoas que me seguem</label
+        >
+        <label
+          ><input id="cfgUnfollowOlderThanChk" type="checkbox" /> Deixar de
+          seguir pessoas que comecei a seguir há mais de
+          <input id="cfgUnfollowOlderThan" type="number" min="0" /> dias (mesmo
+          se me seguirem)</label
+        >
+        <label
+          ><input id="cfgNotUnfollowYoungerThanChk" type="checkbox" /> Não
+          deixar de seguir pessoas que comecei a seguir há menos de
+          <input id="cfgNotUnfollowYoungerThan" type="number" min="0" />
+          dias</label
+        >
+      </div>
+    </div>
+
+    <div id="footer">
+      <div class="dropdown">
+        <button id="loadBtn">Carregar Contas</button>
+        <div id="loadMenu" class="dropdown-menu">
+          <button id="loadFollowers">Carregar Seguidores</button>
+        </div>
+      </div>
+      <button id="process">Processar Fila</button>
+    </div>
+
+    <div id="toast"></div>
+
+    <script src="popup.js"></script>
+  </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,24 +1,366 @@
-function send(msg) {
-  return new Promise(res => chrome.runtime.sendMessage(msg, res));
+const followersPerPage = 10;
+let followers = [];
+let currentPage = 1;
+let currentUsername = null;
+
+document.addEventListener("DOMContentLoaded", () => {
+  bindTabs();
+  bindDropdown();
+  document
+    .getElementById("loadFollowers")
+    .addEventListener("click", loadFollowersHandler);
+  document.getElementById("process").addEventListener("click", processQueue);
+  document
+    .getElementById("start")
+    .addEventListener("click", () =>
+      chrome.runtime.sendMessage({ type: "RUN_START" }),
+    );
+  document
+    .getElementById("stop")
+    .addEventListener("click", () =>
+      chrome.runtime.sendMessage({ type: "RUN_STOP" }),
+    );
+  document
+    .querySelectorAll('input[name="mode"]')
+    .forEach((r) => r.addEventListener("change", onModeChange));
+  document.getElementById("likeCount").addEventListener("change", saveMode);
+  restoreMode();
+  loadConfig();
+});
+
+function bindTabs() {
+  document.querySelectorAll(".tab-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      document
+        .querySelectorAll(".tab-btn")
+        .forEach((b) => b.classList.remove("active"));
+      document
+        .querySelectorAll(".tab-content")
+        .forEach((c) => c.classList.remove("active"));
+      btn.classList.add("active");
+      document.getElementById(btn.dataset.tab).classList.add("active");
+    });
+  });
 }
 
-document.getElementById("follow").onclick = async () => {
-  const u = document.getElementById("username").value.trim();
-  if (!u) return;
-  await send({ type: "QUEUE_ADD", items: [{ kind: "LOOKUP", username: u }] });
-  log("Adicionado follow de @" + u);
-};
+function bindDropdown() {
+  const btn = document.getElementById("loadBtn");
+  const menu = document.getElementById("loadMenu");
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    menu.style.display = menu.style.display === "block" ? "none" : "block";
+  });
+  document.addEventListener("click", () => {
+    menu.style.display = "none";
+  });
+}
 
-document.getElementById("like").onclick = async () => {
-  const u = document.getElementById("username").value.trim();
-  if (!u) return;
-  await send({ type: "QUEUE_ADD", items: [{ kind: "LAST_MEDIA", username: u }] });
-  log("Adicionado like em @" + u);
-};
+async function getActiveTab() {
+  return new Promise((resolve) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) =>
+      resolve(tabs[0]),
+    );
+  });
+}
 
-document.getElementById("start").onclick = () => send({ type: "RUN_START" });
-document.getElementById("stop").onclick = () => send({ type: "RUN_STOP" });
+function extractUsernameFromUrl(url) {
+  const m = url && url.match(/^https?:\/\/www\.instagram\.com\/([^\/]+)\/?/);
+  return m ? m[1] : null;
+}
 
-function log(t) {
-  document.getElementById("log").textContent += t + "\n";
+async function execTaskInActiveTab(task) {
+  const tab = await getActiveTab();
+  return new Promise((resolve, reject) => {
+    chrome.tabs.sendMessage(tab.id, { type: "EXEC_TASK", task }, (resp) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+      } else {
+        resolve(resp);
+      }
+    });
+  });
+}
+
+function getLocal(key) {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(key, (res) => resolve(res[key]));
+  });
+}
+
+function setLocal(key, value) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ [key]: value }, resolve);
+  });
+}
+
+async function loadFollowersHandler() {
+  const tab = await getActiveTab();
+  const username = extractUsernameFromUrl(tab.url);
+  if (!username) {
+    alert("Abra um perfil do Instagram para carregar seguidores.");
+    return;
+  }
+  currentUsername = username;
+  const key = `silent.followers.${username}`;
+  const saved = await getLocal(key);
+  let startIndex = 0;
+  let cursor = null;
+  followers = [];
+  let totalLoaded = 0;
+  if (saved && saved.users && saved.users.length) {
+    const resume = confirm("Você gostaria de tentar continuar de onde parou?");
+    if (resume) {
+      followers = saved.users;
+      cursor = saved.cursor;
+      startIndex = saved.lastIndex || saved.users.length;
+      totalLoaded = startIndex;
+    } else {
+      startIndex =
+        parseInt(
+          prompt(
+            "Limite da fila: 200. Digite o número do seguidor para começar (0 = mais recente).",
+            "0",
+          ),
+          10,
+        ) || 0;
+    }
+  } else {
+    startIndex =
+      parseInt(
+        prompt(
+          "Limite da fila: 200. Digite o número do seguidor para começar (0 = mais recente).",
+          "0",
+        ),
+        10,
+      ) || 0;
+  }
+  let lookup;
+  try {
+    lookup = await execTaskInActiveTab({ kind: "LOOKUP", username });
+  } catch (e) {
+    console.error(e);
+  }
+  if (!lookup || !lookup.userId) {
+    alert("Não foi possível resolver o usuário.");
+    return;
+  }
+  const userId = lookup.userId;
+  while (followers.length < 200) {
+    let res;
+    try {
+      res = await execTaskInActiveTab({
+        kind: "LIST_FOLLOWERS",
+        userId,
+        limit: 24,
+        cursor,
+      });
+    } catch (e) {
+      console.error(e);
+    }
+    if (!res || !res.users) break;
+    for (const u of res.users) {
+      if (totalLoaded < startIndex) {
+        totalLoaded++;
+        continue;
+      }
+      if (followers.length >= 200) break;
+      followers.push({ id: u.id, username: u.username });
+      totalLoaded++;
+    }
+    cursor = res.nextCursor;
+    if (!cursor) break;
+  }
+  await setLocal(key, {
+    users: followers,
+    cursor,
+    totalLoaded,
+    lastIndex: totalLoaded,
+  });
+  currentPage = 1;
+  renderFollowers();
+}
+
+function renderFollowers() {
+  const tbody = document.querySelector("#followersTable tbody");
+  tbody.innerHTML = "";
+  const start = (currentPage - 1) * followersPerPage;
+  const pageUsers = followers.slice(start, start + followersPerPage);
+  pageUsers.forEach((u, idx) => {
+    const tr = document.createElement("tr");
+    const tdCheck = document.createElement("td");
+    const chk = document.createElement("input");
+    chk.type = "checkbox";
+    chk.className = "user-check";
+    chk.dataset.index = start + idx;
+    tdCheck.appendChild(chk);
+    const tdUser = document.createElement("td");
+    tdUser.textContent = "@" + u.username;
+    tr.appendChild(tdCheck);
+    tr.appendChild(tdUser);
+    tbody.appendChild(tr);
+  });
+  renderPagination();
+}
+
+function renderPagination() {
+  const totalPages = Math.ceil(followers.length / followersPerPage);
+  const container = document.getElementById("pagination");
+  container.innerHTML = "";
+  if (totalPages <= 1) return;
+  const prev = document.createElement("button");
+  prev.textContent = "<";
+  prev.disabled = currentPage === 1;
+  prev.addEventListener("click", () => {
+    if (currentPage > 1) {
+      currentPage--;
+      renderFollowers();
+    }
+  });
+  container.appendChild(prev);
+  for (let p = 1; p <= totalPages; p++) {
+    const btn = document.createElement("button");
+    btn.textContent = p;
+    if (p === currentPage) btn.classList.add("active");
+    btn.addEventListener("click", () => {
+      currentPage = p;
+      renderFollowers();
+    });
+    container.appendChild(btn);
+  }
+  const next = document.createElement("button");
+  next.textContent = ">";
+  next.disabled = currentPage === totalPages;
+  next.addEventListener("click", () => {
+    if (currentPage < totalPages) {
+      currentPage++;
+      renderFollowers();
+    }
+  });
+  container.appendChild(next);
+}
+
+function onModeChange() {
+  const mode = document.querySelector('input[name="mode"]:checked');
+  document.getElementById("likeCount").disabled =
+    mode && mode.value !== "follow-like";
+  saveMode();
+}
+
+async function restoreMode() {
+  const data = await getLocal("silent.mode");
+  if (data) {
+    const modeEl = document.querySelector(
+      `input[name="mode"][value="${data.mode}"]`,
+    );
+    if (modeEl) modeEl.checked = true;
+    if (typeof data.likeCount === "number") {
+      document.getElementById("likeCount").value = data.likeCount;
+    }
+  } else {
+    document.querySelector('input[name="mode"][value="follow"]').checked = true;
+  }
+  onModeChange();
+}
+
+function saveMode() {
+  const modeEl = document.querySelector('input[name="mode"]:checked');
+  const likeCount =
+    parseInt(document.getElementById("likeCount").value, 10) || 1;
+  setLocal("silent.mode", {
+    mode: modeEl ? modeEl.value : "follow",
+    likeCount,
+  });
+}
+
+async function processQueue() {
+  if (!followers.length) return;
+  const checked = Array.from(
+    document.querySelectorAll(".user-check:checked"),
+  ).map((c) => followers[parseInt(c.dataset.index, 10)]);
+  const list = checked.length ? checked : followers;
+  const modeEl = document.querySelector('input[name="mode"]:checked');
+  const mode = modeEl ? modeEl.value : "follow";
+  const likeCount =
+    parseInt(document.getElementById("likeCount").value, 10) || 1;
+  const items = [];
+  for (const u of list) {
+    if (mode === "follow") {
+      items.push({ kind: "FOLLOW", userId: u.id });
+    } else if (mode === "follow-like") {
+      items.push({ kind: "FOLLOW", userId: u.id });
+      for (let i = 0; i < likeCount; i++) {
+        items.push({ kind: "LAST_MEDIA", userId: u.id, username: u.username });
+        items.push({ kind: "LIKE" });
+      }
+    } else if (mode === "unfollow") {
+      items.push({ kind: "UNFOLLOW", userId: u.id });
+    }
+  }
+  chrome.runtime.sendMessage({ type: "QUEUE_ADD", items });
+  showToast(`${items.length} tarefas adicionadas à fila.`);
+}
+
+function showToast(msg) {
+  const t = document.getElementById("toast");
+  t.textContent = msg;
+  t.style.display = "block";
+  setTimeout(() => {
+    t.style.display = "none";
+  }, 3000);
+}
+
+async function loadConfig() {
+  const cfg = (await getLocal("silent.cfg.v1")) || {};
+  const ids = [
+    "cfgActionDelay",
+    "cfgSkipDelay",
+    "cfgRandomPercent",
+    "cfgRetrySoft",
+    "cfgRetryHard",
+    "cfgRetry429",
+    "cfgUnfollowOlderThan",
+    "cfgNotUnfollowYoungerThan",
+  ];
+  document.getElementById("cfgKeepFollowers").checked = !!cfg.keepFollowers;
+  document.getElementById("cfgUnfollowOlderThanChk").checked =
+    !!cfg.unfollowOlderThanChk;
+  document.getElementById("cfgNotUnfollowYoungerThanChk").checked =
+    !!cfg.notUnfollowYoungerThanChk;
+  ids.forEach((id) => {
+    if (cfg[id] !== undefined) document.getElementById(id).value = cfg[id];
+  });
+  document
+    .querySelectorAll("#config input")
+    .forEach((el) => el.addEventListener("change", saveConfig));
+}
+
+function saveConfig() {
+  const cfg = {
+    cfgActionDelay:
+      parseInt(document.getElementById("cfgActionDelay").value, 10) || 0,
+    cfgSkipDelay:
+      parseInt(document.getElementById("cfgSkipDelay").value, 10) || 0,
+    cfgRandomPercent:
+      parseInt(document.getElementById("cfgRandomPercent").value, 10) || 0,
+    cfgRetrySoft:
+      parseInt(document.getElementById("cfgRetrySoft").value, 10) || 0,
+    cfgRetryHard:
+      parseInt(document.getElementById("cfgRetryHard").value, 10) || 0,
+    cfgRetry429:
+      parseInt(document.getElementById("cfgRetry429").value, 10) || 0,
+    keepFollowers: document.getElementById("cfgKeepFollowers").checked,
+    unfollowOlderThanChk: document.getElementById("cfgUnfollowOlderThanChk")
+      .checked,
+    unfollowOlderThan:
+      parseInt(document.getElementById("cfgUnfollowOlderThan").value, 10) || 0,
+    notUnfollowYoungerThanChk: document.getElementById(
+      "cfgNotUnfollowYoungerThanChk",
+    ).checked,
+    notUnfollowYoungerThan:
+      parseInt(
+        document.getElementById("cfgNotUnfollowYoungerThan").value,
+        10,
+      ) || 0,
+  };
+  setLocal("silent.cfg.v1", cfg);
 }


### PR DESCRIPTION
## Summary
- add dark themed popup with account queue and settings tabs
- allow loading followers and queuing follow/unfollow/like tasks
- store timing and unfollow rules in local configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68af54f7525483268c8f95e92f7636a4