### PR TITLE
feat: overhaul popup queue and progress handling

### DIFF
--- a/background.js
+++ b/background.js
@@ -53,6 +53,21 @@ async function runOne() {
   if (!tab) { scheduleNext(5000); return; }
 
   chrome.tabs.sendMessage(tab.id, { type: "EXEC_TASK", task }, (res) => {
+    if (chrome.runtime.lastError) {
+      chrome.runtime.sendMessage({
+        type: "TASK_DONE",
+        ok: false,
+        task,
+        error: String(chrome.runtime.lastError.message || chrome.runtime.lastError),
+      });
+    } else {
+      chrome.runtime.sendMessage({
+        type: "TASK_DONE",
+        ok: res?.ok,
+        task,
+        error: res?.error,
+      });
+    }
     console.log("Exec result", res);
     scheduleNext(4000 + Math.random() * 2000);
   });

--- a/popup.css
+++ b/popup.css
@@ -1,9 +1,11 @@
 body {
-  width: 380px;
+  width: 100vw;
+  height: 100vh;
   background: #1f1f1f;
   color: #f1f1f1;
   font-family: system-ui, sans-serif;
   margin: 0;
+  box-sizing: border-box;
 }
 
 #topbar {
@@ -14,12 +16,17 @@ body {
   background: #222;
 }
 
-.tab-btn {
+.tab-btn { 
   background: none;
   border: none;
   color: #f1f1f1;
   padding: 8px 12px;
   cursor: pointer;
+}
+
+#tabs {
+  display: flex;
+  background: #222;
 }
 
 .tab-btn.active {
@@ -153,3 +160,53 @@ input[type="range"] {
 #followersTable td:first-child {
   width: 40px;
 }
+
+#followersTable td:nth-child(2) {
+  width: 40px;
+}
+
+.badge--seguido {
+  background: #2ecc71;
+  color: #fff;
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.dialog.show {
+  display: flex;
+}
+
+.dialog-content {
+  background: #2a2a2a;
+  padding: 16px;
+  width: 100%;
+  max-width: 420px;
+  height: 100vh;
+  overflow: auto;
+  box-sizing: border-box;
+}
+
+.dialog-buttons {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+.dialog-buttons button:first-child {
+  margin-right: 8px;
+}
+

--- a/popup.html
+++ b/popup.html
@@ -6,30 +6,15 @@
     <link rel="stylesheet" href="popup.css" />
   </head>
   <body>
-    <div id="topbar">
-      <div id="tabs">
-        <button class="tab-btn active" data-tab="queue">Fila de Contas</button>
-        <button class="tab-btn" data-tab="config">Configurações</button>
-      </div>
-      <div id="currentUser"></div>
+    <div id="tabs">
+      <button class="tab-btn active" data-tab="queue">Fila de Contas</button>
+      <button class="tab-btn" data-tab="settings">Configurações</button>
     </div>
 
-    <div id="queue" class="tab-content active">
+    <div id="tab-queue" class="tab-content active">
       <div id="runControls" class="card">
         <button id="start">Iniciar</button>
         <button id="stop">Parar</button>
-      </div>
-
-      <div id="actionSelect" class="card">
-        <label><input type="radio" name="mode" value="follow" /> Seguir</label>
-        <label
-          ><input type="radio" name="mode" value="follow-like" /> Seguir +
-          Curtir <input id="likeCount" type="number" min="1" max="3" value="1"
-        /></label>
-        <label
-          ><input type="radio" name="mode" value="unfollow" /> Deixar de
-          seguir</label
-        >
       </div>
 
       <div id="followersContainer" class="card">
@@ -37,7 +22,9 @@
           <thead>
             <tr>
               <th></th>
+              <th></th>
               <th>Usuário</th>
+              <th>Status</th>
             </tr>
           </thead>
           <tbody></tbody>
@@ -46,7 +33,7 @@
       </div>
     </div>
 
-    <div id="config" class="tab-content">
+    <div id="tab-settings" class="tab-content">
       <div class="card">
         <label
           >Aguardar <input id="cfgActionDelay" type="number" min="0" /> segundos
@@ -106,6 +93,21 @@
         </div>
       </div>
       <button id="process">Processar Fila</button>
+    </div>
+
+    <div id="actionDialog" class="dialog">
+      <div class="dialog-content">
+        <label><input type="radio" name="actionMode" value="follow" checked /> Seguir</label>
+        <label>
+          <input type="radio" name="actionMode" value="follow-like" /> Seguir + Curtir
+          <input id="dlgLikeCount" type="number" min="1" max="3" value="1" />
+        </label>
+        <label><input type="radio" name="actionMode" value="unfollow" /> Deixar de seguir</label>
+        <div class="dialog-buttons">
+          <button id="dlgCancel">Cancelar</button>
+          <button id="dlgAdd">Adicionar à Fila</button>
+        </div>
+      </div>
     </div>
 
     <div id="toast"></div>


### PR DESCRIPTION
## Summary
- redesign popup into full-screen overlay with queue grid, pagination, and action dialog
- add follower loading with retry and persistent status badges
- broadcast task completion from background for live updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68af586f36808326a766af578c57038a