### PR TITLE
Implement robust Instagram user lookup with retries and fallbacks

### DIFF
--- a/igClient.js
+++ b/igClient.js
@@ -1,38 +1,69 @@
 // src/igClient.js
+export function csrfFromCookie() {
+  const m = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
+  return m ? decodeURIComponent(m[1]) : "";
+}
+
+export function igHeaders(extra = {}) {
+  return {
+    "x-csrftoken": csrfFromCookie(),
+    "x-ig-app-id": "936619743392459",
+    "x-asbd-id": "129477",
+    "x-instagram-ajax": "1010212815",
+    "x-requested-with": "XMLHttpRequest",
+    ...extra,
+  };
+}
+
+export async function userIdFromUsernameApi(username) {
+  const u = `/api/v1/users/web_profile_info/?username=${encodeURIComponent(
+    username
+  )}`;
+  const res = await fetch(u, { credentials: "include", headers: igHeaders() });
+  const text = await res.text();
+  if (res.status === 302 && /login/i.test(text)) throw new Error("auth_required");
+  if (res.status === 429) throw new Error("http_429");
+  if (res.status === 403) throw new Error("http_403");
+  if (!res.ok) throw new Error(`http_${res.status}`);
+  try {
+    const j = JSON.parse(text);
+    const id = j?.data?.user?.id;
+    if (!id) throw new Error("no_id");
+    return id;
+  } catch {
+    if (/login/i.test(text)) throw new Error("auth_required");
+    throw new Error("parse_json");
+  }
+}
+
 export class IGClient {
   constructor() {
     this.base = "https://www.instagram.com";
   }
 
   getCsrf() {
-    const m = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
-    return m ? decodeURIComponent(m[1]) : null;
+    return csrfFromCookie();
   }
 
   headersJson(extra = {}) {
     return {
       "content-type": "application/x-www-form-urlencoded",
-      "x-csrftoken": this.getCsrf() || "",
-      "x-instagram-ajax": "1010212815",
-      "x-asbd-id": "129477",
-      "x-ig-app-id": "936619743392459",
-      "x-requested-with": "XMLHttpRequest",
-      ...extra
+      ...igHeaders(extra),
     };
   }
 
   async _fetch(path, { method = "GET", body, qs, json = true, headers } = {}) {
-    const url = new URL(path.startsWith("http") ? path : (this.base + path));
+    const url = new URL(path.startsWith("http") ? path : this.base + path);
     if (qs) Object.entries(qs).forEach(([k, v]) => url.searchParams.set(k, v));
     const res = await fetch(url.toString(), {
       method,
       credentials: "include",
       headers: this.headersJson(headers),
-      body
+      body,
     });
     if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      throw new Error(`http_${res.status}:${text.slice(0,140)}`);
+      const txt = await res.text().catch(() => "");
+      throw new Error(`http_${res.status}:${txt.slice(0, 140)}`);
     }
     return json ? res.json() : res.text();
   }
@@ -40,60 +71,79 @@ export class IGClient {
   // ---------- AÇÕES ----------
   async follow(userId) {
     return this._fetch(`/api/v1/friendships/create/${userId}/`, {
-      method: "POST", body: new URLSearchParams({})
+      method: "POST",
+      body: new URLSearchParams({}),
     });
   }
 
   async unfollow(userId) {
     return this._fetch(`/api/v1/friendships/destroy/${userId}/`, {
-      method: "POST", body: new URLSearchParams({})
+      method: "POST",
+      body: new URLSearchParams({}),
     });
   }
 
   async like(mediaId) {
     return this._fetch(`/web/likes/${mediaId}/like/`, {
-      method: "POST", body: new URLSearchParams({})
+      method: "POST",
+      body: new URLSearchParams({}),
     });
   }
 
   async unlike(mediaId) {
     return this._fetch(`/web/likes/${mediaId}/unlike/`, {
-      method: "POST", body: new URLSearchParams({})
+      method: "POST",
+      body: new URLSearchParams({}),
     });
   }
 
   // ---------- LOOKUP ----------
   async userIdFromUsername(username) {
-    // Atenção: esse endpoint retorna HTML, a extensão original deve extrair do JSON embutido.
-    // Aqui simplificamos: tentar versão API v1 (se habilitado)
-    const data = await this._fetch(`/api/v1/users/web_profile_info/?username=${username}`, { json: true });
-    return data?.data?.user?.id;
+    return userIdFromUsernameApi(username);
   }
 
   // ---------- LISTAGENS ----------
   async listFollowers({ userId, limit = 24, cursor = null }) {
     const qs = {
       query_hash: "7dd9a7e2160524fd85f50317462cff9f",
-      variables: JSON.stringify({ id: userId, include_reel: true, fetch_mutual: false, first: limit, after: cursor })
+      variables: JSON.stringify({
+        id: userId,
+        include_reel: true,
+        fetch_mutual: false,
+        first: limit,
+        after: cursor,
+      }),
     };
     const data = await this._fetch("/graphql/query/", { qs, json: true });
     const cont = data?.data?.user?.edge_followed_by;
     return {
-      users: cont?.edges?.map(e => ({ id: e.node.id, username: e.node.username })) || [],
-      nextCursor: cont?.page_info?.has_next_page ? cont.page_info.end_cursor : null
+      users:
+        cont?.edges?.map((e) => ({ id: e.node.id, username: e.node.username })) || [],
+      nextCursor: cont?.page_info?.has_next_page
+        ? cont.page_info.end_cursor
+        : null,
     };
   }
 
   async listFollowing({ userId, limit = 24, cursor = null }) {
     const qs = {
       query_hash: "c56ee0ae1f89cdbd1c89e2bc6b8f3d18",
-      variables: JSON.stringify({ id: userId, include_reel: true, fetch_mutual: false, first: limit, after: cursor })
+      variables: JSON.stringify({
+        id: userId,
+        include_reel: true,
+        fetch_mutual: false,
+        first: limit,
+        after: cursor,
+      }),
     };
     const data = await this._fetch("/graphql/query/", { qs, json: true });
     const cont = data?.data?.user?.edge_follow;
     return {
-      users: cont?.edges?.map(e => ({ id: e.node.id, username: e.node.username })) || [],
-      nextCursor: cont?.page_info?.has_next_page ? cont.page_info.end_cursor : null
+      users:
+        cont?.edges?.map((e) => ({ id: e.node.id, username: e.node.username })) || [],
+      nextCursor: cont?.page_info?.has_next_page
+        ? cont.page_info.end_cursor
+        : null,
     };
   }
 
@@ -102,16 +152,25 @@ export class IGClient {
     // Versão GraphQL
     const qs = {
       doc_id: "8633614153419931",
-      variables: JSON.stringify({ id: userId, first: 12 })
+      variables: JSON.stringify({ id: userId, first: 12 }),
     };
     try {
-      const data = await this._fetch("/graphql/query/", { qs, json: true, method: "POST" });
-      const node = data?.data?.user?.edge_owner_to_timeline_media?.edges?.[0]?.node;
+      const data = await this._fetch("/graphql/query/", {
+        qs,
+        json: true,
+        method: "POST",
+      });
+      const node =
+        data?.data?.user?.edge_owner_to_timeline_media?.edges?.[0]?.node;
       return node?.id;
     } catch (e) {
       // fallback API v1
-      const data = await this._fetch(`/api/v1/feed/user/${username}/username/?count=12`, { json: true });
+      const data = await this._fetch(
+        `/api/v1/feed/user/${username}/username/?count=12`,
+        { json: true }
+      );
       return data?.items?.[0]?.id;
     }
   }
 }
+

--- a/runner.js
+++ b/runner.js
@@ -1,4 +1,95 @@
-import { IGClient } from "./igClient.js";
+import {
+  IGClient,
+  igHeaders,
+  userIdFromUsernameApi,
+} from "./igClient.js";
+
+function delay(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function s1(username) {
+  return userIdFromUsernameApi(username);
+}
+
+async function s2(username) {
+  const res = await fetch(`/${encodeURIComponent(username)}/`, {
+    credentials: "include",
+    headers: igHeaders(),
+  });
+  const html = await res.text();
+  if (res.status === 429) throw new Error("http_429");
+  if (res.status === 403) throw new Error("http_403");
+  if (!res.ok) throw new Error(`http_${res.status}`);
+  if (/login/i.test(html)) throw new Error("auth_required");
+  const ld = html.match(
+    /<script type="application\/ld\+json">([\s\S]*?)<\/script>/i
+  );
+  if (ld) {
+    try {
+      const data = JSON.parse(ld[1]);
+      const sameAs = (
+        data?.mainEntityOfPage?.["@id"] || data?.url || ""
+      ).toString();
+      const mld = sameAs.match(/profilePage_(\d+)/);
+      if (mld?.[1]) return mld[1];
+    } catch {}
+  }
+  const m = html.match(/"profilePage_(\d+)"/);
+  if (m?.[1]) return m[1];
+  const m2 = html.match(
+    new RegExp(
+      `"id":"(\\d+)","username":"${username.replace(
+        /[-/\\^$*+?.()|[\]{}]/g,
+        "\\$&"
+      )}"`
+    )
+  );
+  if (m2?.[1]) return m2[1];
+  throw new Error("parse_failed");
+}
+
+async function s3(username) {
+  const body = new URLSearchParams({
+    doc_id: "8845758582119845",
+    variables: JSON.stringify({ username }),
+  });
+  const res = await fetch("/graphql/query", {
+    method: "POST",
+    credentials: "include",
+    headers: igHeaders({
+      "content-type": "application/x-www-form-urlencoded",
+    }),
+    body,
+  });
+  const text = await res.text();
+  if (res.status === 429) throw new Error("http_429");
+  if (res.status === 403) throw new Error("http_403");
+  if (!res.ok) throw new Error(`http_${res.status}`);
+  if (/login/i.test(text)) throw new Error("auth_required");
+  try {
+    const j = JSON.parse(text);
+    const id = j?.data?.user?.id || j?.data?.user_by_username?.id;
+    if (!id) throw new Error("no_id");
+    return id;
+  } catch {
+    throw new Error("parse_json");
+  }
+}
+
+async function lookupUserIdRobust(username) {
+  const strategies = [s1, s2, s3];
+  let lastErr = "none";
+  for (let i = 0; i < strategies.length; i++) {
+    try {
+      return await strategies[i](username);
+    } catch (e) {
+      lastErr = e.message || String(e);
+      await delay(200 * (i + 1));
+    }
+  }
+  throw new Error("lookup_failed:" + lastErr);
+}
 
 export class IGRunner {
   constructor() {
@@ -13,8 +104,10 @@ export class IGRunner {
         return await this.ig.unfollow(task.userId);
       case "LIKE":
         return await this.ig.like(task.mediaId);
-      case "LOOKUP":
-        return await this.ig.userIdFromUsername(task.username);
+      case "LOOKUP": {
+        const userId = await lookupUserIdRobust(task.username);
+        return { userId };
+      }
       case "LIST_FOLLOWERS":
         return await this.ig.listFollowers(task);
       case "LIST_FOLLOWING":


### PR DESCRIPTION
## Summary
- add utility to parse profile usernames from varied Instagram URLs
- implement multi-strategy userId lookup with retries and detailed errors
- standardize IG request headers and CSRF extraction

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `node -e "import('./panel.js').then(m=>{console.log(m.extractUsernameFromUrl('https://www.instagram.com/testuser/'));console.log(m.extractUsernameFromUrl('https://www.instagram.com/testuser/reels/'));console.log(m.extractUsernameFromUrl('https://www.instagram.com/accounts/login/'));});"`


------
https://chatgpt.com/codex/tasks/task_e_68af5f6bd27c8326b84db4ab2c8bfca3