### PR TITLE
feat: show queue with user logs

### DIFF
--- a/panel.css
+++ b/panel.css
@@ -157,12 +157,25 @@ input[type="range"] {
   width: 40px;
 }
 
-.badge--seguido {
-  background: #2ecc71;
-  color: #fff;
+.badge {
   padding: 2px 4px;
   border-radius: 4px;
   font-size: 12px;
+}
+
+.badge--seguido {
+  background: #2ecc71;
+  color: #fff;
+}
+
+.badge--like {
+  background: #e57373;
+  color: #fff;
+}
+
+.badge--unfollow {
+  background: #777;
+  color: #fff;
 }
 
 .dialog {

--- a/panel.html
+++ b/panel.html
@@ -64,7 +64,7 @@
       <label><input type="radio" name="actionMode" value="unfollow" /> Deixar de seguir</label>
       <div class="dialog-buttons">
         <button id="dlgCancel">Cancelar</button>
-        <button id="dlgAdd">Adicionar à Fila</button>
+        <button id="dlgAdd">Iniciar</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show queued profiles with status badges and logs
- add start/stop controls with persistent queue state
- start processing from dialog and switch to queue tab

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68af6308446c832686302d06a184618c