### PR TITLE
Add fullscreen overlay panel with HUD and execution log

### DIFF
--- a/panel.css
+++ b/panel.css
@@ -1,11 +1,38 @@
+/* root do overlay (fora do #panel) */
+:host, :root {
+  all: initial;
+}
+
+#igx-root {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  pointer-events: auto;
+}
+
+/* backdrop opcional se quiser escurecer o site
+#igx-root::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,.35);
+}
+*/
+
 #panel {
-  width: 100%;
-  height: 100%;
+  position: relative;
+  width: 420px;
+  height: 100vh;
   background: #1f1f1f;
   color: #f1f1f1;
   font-family: system-ui, sans-serif;
   margin: 0;
   box-sizing: border-box;
+  overflow: auto;
+  box-shadow: -2px 0 10px rgba(0,0,0,.6);
 }
 
 .tab-btn {

--- a/panel.html
+++ b/panel.html
@@ -1,32 +1,41 @@
-<div id="panel">
-  <div id="tabs">
-    <button class="tab-btn active" data-tab="queue">Fila de Contas</button>
-    <button class="tab-btn" data-tab="settings">Configurações</button>
-  </div>
-
-  <div id="tab-queue" class="tab-content active">
-    <div id="runControls" class="card">
-      <button id="start">Iniciar</button>
-      <button id="stop">Parar</button>
+<div id="igx-root">
+  <div id="panel">
+    <div id="tabs">
+      <button class="tab-btn active" data-tab="queue">Fila de Contas</button>
+      <button class="tab-btn" data-tab="settings">Configurações</button>
     </div>
 
-    <div id="followersContainer" class="card">
-      <table id="followersTable">
-        <thead>
-          <tr>
-            <th></th>
-            <th></th>
-            <th>Usuário</th>
-            <th>Status</th>
-          </tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-      <div id="pagination"></div>
-    </div>
-  </div>
+    <div id="tab-queue" class="tab-content active">
+      <div id="runControls" class="card">
+        <button id="start">Iniciar</button>
+        <button id="stop">Parar</button>
+      </div>
 
-  <div id="tab-settings" class="tab-content">
+      <div id="followersContainer" class="card">
+        <table id="followersTable">
+          <thead>
+            <tr>
+              <th></th>
+              <th></th>
+              <th>Usuário</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <div id="pagination"></div>
+      </div>
+
+      <div id="runLogCard" class="card">
+        <div style="display:flex;justify-content:space-between;align-items:center;">
+          <strong>Log de execução</strong>
+          <button id="clearLog" style="background:#444">Limpar</button>
+        </div>
+        <div id="runLog" style="max-height:180px;overflow:auto;font-family:ui-monospace,monospace;font-size:12px;background:#111;padding:6px;border-radius:4px;margin-top:6px;"></div>
+      </div>
+    </div>
+
+    <div id="tab-settings" class="tab-content">
     <div class="card">
       <label>Aguardar <input id="cfgActionDelay" type="number" min="0" /> segundos após seguir/deixar de seguir/curtir</label>
       <label>Aguardar <input id="cfgSkipDelay" type="number" min="0" /> segundos após pular</label>
@@ -44,30 +53,39 @@
     </div>
   </div>
 
-  <div id="footer">
-    <div class="dropdown">
-      <button id="loadBtn">Carregar Contas</button>
-      <div id="loadMenu" class="dropdown-menu">
-        <button id="loadFollowers">Carregar Seguidores</button>
+    <div id="footer">
+      <div class="dropdown">
+        <button id="loadBtn">Carregar Contas</button>
+        <div id="loadMenu" class="dropdown-menu">
+          <button id="loadFollowers">Carregar Seguidores</button>
+        </div>
+      </div>
+      <button id="process">Processar Fila</button>
+    </div>
+
+    <div id="actionDialog" class="dialog">
+      <div class="dialog-content">
+        <label><input type="radio" name="actionMode" value="follow" checked /> Seguir</label>
+        <label>
+          <input type="radio" name="actionMode" value="follow-like" /> Seguir + Curtir
+          <input id="dlgLikeCount" type="number" min="1" max="3" value="1" />
+        </label>
+        <label><input type="radio" name="actionMode" value="unfollow" /> Deixar de seguir</label>
+        <div class="dialog-buttons">
+          <button id="dlgCancel">Cancelar</button>
+          <button id="dlgAdd">Iniciar</button>
+        </div>
       </div>
     </div>
-    <button id="process">Processar Fila</button>
-  </div>
 
-  <div id="actionDialog" class="dialog">
-    <div class="dialog-content">
-      <label><input type="radio" name="actionMode" value="follow" checked /> Seguir</label>
-      <label>
-        <input type="radio" name="actionMode" value="follow-like" /> Seguir + Curtir
-        <input id="dlgLikeCount" type="number" min="1" max="3" value="1" />
-      </label>
-      <label><input type="radio" name="actionMode" value="unfollow" /> Deixar de seguir</label>
-      <div class="dialog-buttons">
-        <button id="dlgCancel">Cancelar</button>
-        <button id="dlgAdd">Iniciar</button>
-      </div>
-    </div>
+    <div id="toast"></div>
   </div>
-
-  <div id="toast"></div>
+</div>
+<div id="runHud" style="
+  position: fixed; bottom: 12px; right: 440px; z-index: 2147483647;
+  background:#222; color:#fff; padding:8px 10px; border-radius:8px;
+  box-shadow:0 2px 8px rgba(0,0,0,.5); font-size:13px; line-height:1.3;">
+  <div><strong>Progresso:</strong> <span id="hudProgress">0/0</span></div>
+  <div><strong>Ação:</strong> <span id="hudAction">—</span></div>
+  <div><strong>Próxima em:</strong> <span id="hudCountdown">--:--</span></div>
 </div>


### PR DESCRIPTION
## Summary
- Render panel as a fullscreen overlay and inject it with a content script toggle.
- Include a persistent execution log and floating HUD with progress and countdown.
- Broadcast task progress from the background to update HUD and log in real time.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b6085208832684bd900801892f46