### PR TITLE
Fix like task and reset queue on panel open

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -260,15 +260,14 @@ async function confirmProcess() {
       error: undefined,
     };
     if (mode === "follow") {
-      items.push({ kind: "FOLLOW", userId: u.id });
+      items.push({ kind: "FOLLOW", userId: u.id, username: u.username });
     } else if (mode === "follow-like") {
-      items.push({ kind: "FOLLOW", userId: u.id });
+      items.push({ kind: "FOLLOW", userId: u.id, username: u.username });
       for (let i = 0; i < likeCount; i++) {
-        items.push({ kind: "LAST_MEDIA", userId: u.id, username: u.username });
-        items.push({ kind: "LIKE", userId: u.id });
+        items.push({ kind: "LIKE", userId: u.id, username: u.username });
       }
     } else if (mode === "unfollow") {
-      items.push({ kind: "UNFOLLOW", userId: u.id });
+      items.push({ kind: "UNFOLLOW", userId: u.id, username: u.username });
     }
     u.status = st;
     snapshot.push({ userId: u.id, username: u.username, likesPlanned: st.likesTotal });


### PR DESCRIPTION
## Summary
- resolve first likeable media and send in-page like request with proper headers
- reset stored follower queue when opening the panel and start fresh on load
- include usernames in like tasks and remove redundant LAST_MEDIA tasks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0be4ed4d0832681e081fca059fc5b