### PR TITLE
fix: reset panel state and fullscreen overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/contentscript.js
+++ b/contentscript.js
@@ -27,8 +27,9 @@ chrome.runtime.onMessage.addListener(async (msg, _s, _send) => {
   let root = document.getElementById("igx-panel-root");
   if (root) {
     root.remove();
-    return;
+    if (!msg.open) return;
   }
+  if (msg.open === false) return;
   root = document.createElement("div");
   root.id = "igx-panel-root";
   const shadow = root.attachShadow({ mode: "open" });

--- a/panel.js
+++ b/panel.js
@@ -26,10 +26,15 @@ export function init(root) {
   (async () => {
     const username = extractUsernameFromUrl(location.href);
     if (username) {
+      currentUsername = username;
       await chrome.storage.local.remove(STATE_KEY(username));
       await chrome.storage.local.remove(`silent.queueView.${username}`);
-      clearUIList();
+    } else {
+      currentUsername = null;
     }
+    queueView = null;
+    clearUIList();
+    clearRunLog();
   })();
   bindTabs();
   bindDropdown();
@@ -50,7 +55,6 @@ export function init(root) {
     .forEach((r) => r.addEventListener("change", onDialogModeChange));
   onDialogModeChange();
   loadConfig();
-  restoreState().then(restoreLog);
   updateRunButtons(false);
   on("#clearLog", "click", clearRunLog);
   chrome.runtime.onMessage.addListener(handleRuntimeMessage);
@@ -342,6 +346,14 @@ function clearUIList() {
   followers = [];
   followersState = { cursor: null, totalLoaded: 0, lastIndex: 0 };
   currentPage = 1;
+  queueView = null;
+  lastRenderedUser = null;
+  const hp = qs("#hudProgress");
+  if (hp) hp.textContent = "0/0";
+  const ha = qs("#hudAction");
+  if (ha) ha.textContent = "—";
+  const hc = qs("#hudCountdown");
+  if (hc) hc.textContent = "--:--";
 }
 
 function renderStatus(td, st) {


### PR DESCRIPTION
## Summary
- inject panel overlay in Shadow DOM, recreating root each open
- clear follower queue and HUD on panel load to avoid rehydration
- add gitignore for node_modules

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c164973883269d1ef59e5ae1a413