### PR TITLE
Implement paginated follower/following collection

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -11,6 +11,7 @@
         <button id="btnLoad">Carregar Contas</button>
         <div id="loadMenu" class="menu">
           <button id="btnLoadFollowers">Carregar Seguidores da Página Atual</button>
+          <button id="btnLoadFollowing">Carregar Seguidos da Página Atual</button>
         </div>
       </div>
       <div class="dropdown">

--- a/panel.js
+++ b/panel.js
@@ -25,6 +25,11 @@ window.addEventListener('message', (ev) => {
   if (msg.type === 'PANEL_READY') {
     init();
   } else if (msg.type === 'FOLLOWERS_LOADED') {
+    qs('#progressHud').classList.add('hidden');
+    if (msg.error) {
+      alert(msg.error);
+      return;
+    }
     followers = msg.items || [];
     page = 1;
     renderTable();
@@ -51,6 +56,10 @@ function init() {
   qs('#btnLoadFollowers').addEventListener('click', () => {
     const limit = parseInt(qs('#limit').value, 10) || 0;
     send({ type: 'LOAD_FOLLOWERS', limit });
+  });
+  qs('#btnLoadFollowing').addEventListener('click', () => {
+    const limit = parseInt(qs('#limit').value, 10) || 0;
+    send({ type: 'LOAD_FOLLOWING', limit });
   });
   qs('#btnProcess').addEventListener('click', () => {
     toggleMenu('#processMenu');


### PR DESCRIPTION
## Summary
- support loading both followers and following with configurable limit
- show progress while collecting and handle errors gracefully

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e860b2788326ad89298eb2d6ad30