### PR TITLE
Refactor command routing and handshake

### DIFF
--- a/injected.js
+++ b/injected.js
@@ -6,8 +6,11 @@ window.addEventListener("message", async (ev) => {
   if (!ev.data?.__BOT__) return;
   if (ev.data.type === "TASK") {
     try {
-      const out = await runner.execute(ev.data.task);
-      window.postMessage({ __BOT__: true, type: "TASK_RESULT", payload: { ok: true, out } }, "*");
+      const data = await runner.execute(ev.data.task);
+      window.postMessage(
+        { __BOT__: true, type: "TASK_RESULT", payload: { ok: true, data } },
+        "*",
+      );
     } catch (e) {
       window.postMessage({ __BOT__: true, type: "TASK_RESULT", payload: { ok: false, error: String(e) } }, "*");
     }


### PR DESCRIPTION
## Summary
- standardize service worker command handling with timeout and EXEC messages
- add content script dispatcher relaying commands to page and unify {ok,data|error} responses
- adjust injected runner to send payloads in new format

## Testing
- `npm run lint` *(fails: ESLint configuration not found)*
- `node --check background.js contentscript.js injected.js panel.js popup.js igClient.js runner.js`

------
https://chatgpt.com/codex/tasks/task_e_68b5f17673b88326aadd2caf019214d8