### PR TITLE
Implement robust messaging circuit

### DIFF
--- a/background.js
+++ b/background.js
@@ -44,25 +44,25 @@ function stop() {
 
 function execCommand(tabId, action, payload) {
   return new Promise((resolve) => {
-    let done = false;
+    let finished = false;
+    const handleResult = (res) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      resolve(res);
+    };
     const timer = setTimeout(() => {
-      if (!done) {
-        done = true;
-        resolve({ ok: false, error: 'no_response' });
-      }
-    }, 10000);
+      handleResult({ ok: false, error: 'timeout' });
+    }, 5000);
     log('exec', action, payload);
     chrome.tabs.sendMessage(
       tabId,
-      { type: 'EXEC', action, payload },
-      (res) => {
-        if (done) return;
-        done = true;
-        clearTimeout(timer);
+      { type: 'EXEC_TASK', action, payload },
+      (response) => {
         if (chrome.runtime.lastError) {
-          resolve({ ok: false, error: chrome.runtime.lastError.message });
+          handleResult({ ok: false, error: chrome.runtime.lastError.message });
         } else {
-          resolve(res || { ok: false, error: 'no_response' });
+          handleResult(response || { ok: false, error: 'no_response' });
         }
       },
     );


### PR DESCRIPTION
## Summary
- add timeout and error handling when service worker dispatches tasks
- forward EXEC_TASK messages through a unified dispatcher in the content script

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f75d1608832686521a74a084cee9