### PR TITLE
Implement ping-based messaging health checks

### DIFF
--- a/injected.js
+++ b/injected.js
@@ -6,32 +6,21 @@ function log(...args) {
   console.debug('[page]', ...args);
 }
 
-window.addEventListener("message", async (ev) => {
-  const msg = ev.data;
-  if (!msg?.__BOT__ || msg.type !== "TASK") return;
+window.addEventListener('message', async (ev) => {
+  const d = ev.data;
+  if (!d || !d.__BOT__ || d.type !== 'TASK') return;
+  const { requestId, action, payload } = d;
   try {
-    log('task', msg.action);
-    const data = await runner.execute({ kind: msg.action, ...(msg.payload || {}) });
-    window.postMessage(
-      {
-        __BOT__: true,
-        type: "TASK_RESULT",
-        requestId: msg.requestId,
-        ok: true,
-        data,
-      },
-      "*",
-    );
+    if (action === 'ping_page') {
+      return window.postMessage({ type: 'TASK_RESULT', requestId, ok: true, from: 'page' }, '*');
+    }
+    log('task', action);
+    const data = await runner.execute({ kind: action, ...(payload || {}) });
+    window.postMessage({ type: 'TASK_RESULT', requestId, ok: true, data }, '*');
   } catch (e) {
     window.postMessage(
-      {
-        __BOT__: true,
-        type: "TASK_RESULT",
-        requestId: msg.requestId,
-        ok: false,
-        error: String(e),
-      },
-      "*",
+      { type: 'TASK_RESULT', requestId, ok: false, error: (e && e.message) || String(e) },
+      '*',
     );
   }
 });


### PR DESCRIPTION
## Summary
- Add PING_SW handler and generic sendToTab helper with timeout in background script
- Content script now pings SW on load and replies to PING_CS while forwarding task results
- Injected page script handles ping_page and returns TASK_RESULT messages without bot flag

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `node --check background.js`
- `node --check contentscript.js`
- `node --check injected.js`

------
https://chatgpt.com/codex/tasks/task_e_68b5f9676bd083269f1b3a20e4a01535