### PR TITLE
Fix queue start flow and config handling

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -60,7 +60,9 @@ if (window.__IG_CS_TASK_HANDLER) {
       );
       return true;
     } else if (
-      ['ROW_UPDATE', 'PROGRESS', 'STOPPED', 'FOLLOWERS_LOADED'].includes(msg.type)
+      ['ROW_UPDATE', 'PROGRESS', 'DONE', 'STOPPED', 'FOLLOWERS_LOADED'].includes(
+        msg.type,
+      )
     ) {
       window.postMessage(msg, '*');
     }
@@ -174,13 +176,20 @@ window.addEventListener("message", async (ev) => {
       { type: "FOLLOWERS_LOADED", items: res.items, total: res.total, error: res.error },
       "*",
     );
-  } else if (msg.type === "START_PROCESS") {
-    chrome.runtime.sendMessage({
-      type: "START_PROCESS",
-      items: msg.items,
-      settings: msg.settings,
-    });
-  } else if (msg.type === "STOP_PROCESS") {
-    chrome.runtime.sendMessage({ type: "STOP_PROCESS" });
+  } else if (msg.type === "START_QUEUE") {
+    chrome.runtime.sendMessage(
+      {
+        type: "START_QUEUE",
+        mode: msg.mode,
+        likeCount: msg.likeCount,
+        targets: msg.targets,
+        cfg: msg.cfg,
+      },
+      (resp) => {
+        window.postMessage({ type: "QUEUE_STARTED", ok: resp?.ok }, "*");
+      },
+    );
+  } else if (msg.type === "STOP_QUEUE") {
+    chrome.runtime.sendMessage({ type: "STOP_QUEUE" });
   }
 });

--- a/panel.html
+++ b/panel.html
@@ -14,12 +14,12 @@
           <button id="btnLoadFollowing">Carregar Seguidos da Página Atual</button>
         </div>
       </div>
-      <div class="dropdown">
+      <div class="dropdown" id="dropdownProcess">
         <button id="btnProcess">Processar Fila</button>
         <div id="processMenu" class="menu">
-          <label><input type="radio" name="actionMode" value="follow" checked> Seguir</label>
-          <label><input type="radio" name="actionMode" value="follow_like"> Seguir + Curtir <input id="likeCount" type="number" min="1" max="12" value="1"></label>
-          <label><input type="radio" name="actionMode" value="unfollow"> Deixar de seguir</label>
+          <label><input id="modeFollow" type="radio" name="actionMode" value="follow" checked> Seguir</label>
+          <label><input id="modeFollowLike" type="radio" name="actionMode" value="follow_like"> Seguir + Curtir <input id="likeCount" type="number" min="0" max="12" value="1"></label>
+          <label><input id="modeUnfollow" type="radio" name="actionMode" value="unfollow"> Deixar de seguir</label>
           <div class="dialog-buttons"><button id="btnProcessConfirm">Iniciar</button></div>
         </div>
       </div>
@@ -51,10 +51,19 @@
     </div>
   </div>
   <div id="tab-settings" class="tab-content">
-    <div class="card">
-      <label>Aguardar <input id="cfgDelay" type="number" min="0" /> ms entre ações</label>
-      <label>Aleatório até <input id="cfgJitter" type="number" min="0" max="100" />%</label>
-      <label>Tamanho da página padrão <input id="cfgPageSize" type="number" min="10" max="200" step="10" /></label>
-    </div>
+      <div class="card">
+        <label>Aguardar <input id="cfgDelayMs" type="number" min="0" /> ms entre ações</label>
+        <label>Aleatório até <input id="cfgJitterPct" type="number" min="0" max="100" />%</label>
+        <label>Tamanho da página padrão <input id="cfgPageSize" type="number" min="10" max="200" step="10" /></label>
+        <label>Curtidas por perfil (default) <input id="cfgLikePerProfile" type="number" min="0" max="12" /></label>
+        <label>Modo padrão
+          <select id="cfgMode">
+            <option value="follow">Seguir</option>
+            <option value="follow_like">Seguir + Curtir</option>
+            <option value="unfollow">Deixar de seguir</option>
+          </select>
+        </label>
+        <div class="dialog-buttons"><button id="cfgSave">Salvar</button></div>
+      </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Ensure Processar Fila → Iniciar dispatches a single START_QUEUE message with targets and config snapshot
- Persist extension settings with a unified schema and update UI state around queue processing
- Forward START_QUEUE/EXEC_TASK between panel, content script and service worker with progress events and completion/stop notifications

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fc2822bc832697b5ec102edb5b23