### PR TITLE
Add execution overlay and queued timing controls

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -60,7 +60,7 @@ if (window.__IG_CS_TASK_HANDLER) {
       );
       return true;
     } else if (
-      ['ROW_UPDATE', 'PROGRESS', 'DONE', 'STOPPED', 'FOLLOWERS_LOADED'].includes(
+      ['ROW_UPDATE', 'QUEUE_TICK', 'QUEUE_DONE', 'FOLLOWERS_LOADED'].includes(
         msg.type,
       )
     ) {

--- a/panel.css
+++ b/panel.css
@@ -75,21 +75,6 @@ button:disabled {
   background: #444;
   margin: 0 2px;
 }
-.hud {
-  position: fixed;
-  bottom: 10px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #222;
-  padding: 6px 10px;
-  border-radius: 6px;
-  display: flex;
-  gap: 10px;
-  align-items: center;
-}
-.hud.hidden {
-  display: none;
-}
 .badge {
   padding: 2px 4px;
   border-radius: 4px;
@@ -112,4 +97,21 @@ button:disabled {
 }
 .tab-content.active {
   display: block;
+}
+
+#rsx-overlay {
+  position: fixed;
+  left: 16px;
+  bottom: 16px;
+  background: rgba(20, 20, 20, 0.85);
+  color: #eee;
+  font: 12px/1.4 system-ui, sans-serif;
+  padding: 10px 12px;
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  z-index: 2147483647;
+  pointer-events: none;
+}
+#rsx-overlay .rsx-ov-line {
+  margin: 2px 0;
 }

--- a/panel.html
+++ b/panel.html
@@ -44,11 +44,6 @@
         </select>
       </div>
     </div>
-    <div id="progressHud" class="hud hidden">
-      <span id="progressText">0/0</span>
-      <span>Próxima em <span id="countdown">00:00</span></span>
-      <button id="btnStopHud">Parar</button>
-    </div>
   </div>
   <div id="tab-settings" class="tab-content">
       <div class="card">
@@ -66,4 +61,10 @@
         <div class="dialog-buttons"><button id="cfgSave">Salvar</button></div>
       </div>
   </div>
+</div>
+
+<div id="rsx-overlay" class="rsx-ov">
+  <div class="rsx-ov-line"><b>Próxima ação em:</b> <span id="rsx-eta">--:--.-</span></div>
+  <div class="rsx-ov-line"><b>Progresso:</b> <span id="rsx-prog">0 / 0</span></div>
+  <div class="rsx-ov-line"><b>Status:</b> <span id="rsx-phase">idle</span></div>
 </div>


### PR DESCRIPTION
## Summary
- Add floating overlay to show next action countdown, progress and status
- Implement sequential queue execution with jitter and exponential backoff
- Stream queue tick updates from service worker to panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b6013dfd1083268e7561d10d43084b