### PR TITLE
Show delay in seconds

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -47,7 +47,7 @@
   </div>
   <div id="tab-settings" class="tab-content">
       <div class="card">
-        <label>Aguardar <input id="cfgDelayMs" type="number" min="0" /> ms entre ações</label>
+        <label>Delay (segundos) <input id="cfgDelaySec" type="number" min="0" title="Segundos entre ações" /> </label>
         <label>Aleatório até <input id="cfgJitterPct" type="number" min="0" max="100" />%</label>
         <label>Tamanho da página padrão <input id="cfgPageSize" type="number" min="10" max="200" step="10" /></label>
         <label>Curtidas por perfil (default) <input id="cfgLikePerProfile" type="number" min="0" max="12" /></label>

--- a/panel.js
+++ b/panel.js
@@ -256,7 +256,10 @@ function handleLikeInput() {
 
 function getCurrentCfg() {
   return {
-    baseDelayMs: +qs('#cfgDelayMs').value || cfg.baseDelayMs || DEFAULT_CFG.baseDelayMs,
+    baseDelayMs:
+      (parseInt(qs('#cfgDelaySec').value, 10) * 1000) ||
+      cfg.baseDelayMs ||
+      DEFAULT_CFG.baseDelayMs,
     jitterPct: +qs('#cfgJitterPct').value || cfg.jitterPct || DEFAULT_CFG.jitterPct,
     pageSize: cfg.pageSize || DEFAULT_CFG.pageSize,
     likePerProfile:
@@ -272,7 +275,7 @@ function saveCfgFromInputs() {
   qs('#likeCount').value = String(cfg.likePerProfile);
   qs('#cfgPageSize').value = cfg.pageSize;
   qs('#pageSize').value = String(cfg.pageSize);
-  qs('#cfgDelayMs').value = cfg.baseDelayMs;
+  qs('#cfgDelaySec').value = Math.floor(cfg.baseDelayMs / 1000);
   qs('#cfgJitterPct').value = cfg.jitterPct;
   qs('#cfgLikePerProfile').value = cfg.likePerProfile;
   qs('#cfgMode').value = cfg.actionModeDefault;
@@ -288,7 +291,7 @@ function saveCfgFromInputs() {
 function loadCfg() {
   chrome.storage.local.get(DEFAULT_CFG, (st) => {
     cfg = { ...DEFAULT_CFG, ...st };
-    qs('#cfgDelayMs').value = cfg.baseDelayMs;
+    qs('#cfgDelaySec').value = Math.floor(cfg.baseDelayMs / 1000);
     qs('#cfgJitterPct').value = cfg.jitterPct;
     qs('#cfgPageSize').value = cfg.pageSize;
     qs('#cfgLikePerProfile').value = cfg.likePerProfile;


### PR DESCRIPTION
## Summary
- display delay input in seconds
- convert between seconds in UI and milliseconds in storage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b6039a67c48326a15687628213e5ae