### PR TITLE
feat: central queue scheduler

### DIFF
--- a/background.js
+++ b/background.js
@@ -5,17 +5,21 @@ const DEFAULT_CFG = {
   likePerProfile: 1,
   actionModeDefault: 'follow_like',
 };
-let queue = [];
-let running = false;
-let processed = 0;
-let timer = null;
-let total = 0;
-let state = { mode: 'follow', likeCount: 0, cfg: { ...DEFAULT_CFG } };
+
 let cachedCfg = { ...DEFAULT_CFG };
-let nextActionAt = null;
+let state = { mode: 'follow', likeCount: 0, cfg: { ...DEFAULT_CFG } };
+const q = {
+  items: [],
+  idx: 0,
+  processed: 0,
+  total: 0,
+  isRunning: false,
+  timer: null,
+  phase: 'idle',
+  nextActionAt: null,
+  backoffStep: 0,
+};
 let activeTabId = null;
-let lock = false;
-let backoffStep = 0;
 
 function log(...args) {
   console.debug('[bg]', ...args);
@@ -25,7 +29,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg?.type === 'PING_SW') {
     sendResponse({ ok: true, from: 'sw' });
   } else if (msg.type === 'START_QUEUE') {
-    if (running) return sendResponse({ ok: false, error: 'already_running' });
+    if (q.isRunning) return sendResponse({ ok: false, error: 'already_running' });
     const { mode, likeCount, targets, cfg } = msg;
     if (!['follow', 'follow_like', 'unfollow'].includes(mode))
       return sendResponse({ ok: false, error: 'invalid_mode' });
@@ -36,23 +40,25 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       if (!activeTabId) {
         return sendResponse({ ok: false, error: 'no_tab' });
       }
-      queue = targets.slice();
-      processed = 0;
-      total = queue.length;
+      q.items = targets.slice();
+      q.idx = 0;
+      q.processed = 0;
+      q.total = q.items.length;
+      q.isRunning = true;
+      q.phase = 'idle';
+      q.nextActionAt = null;
+      q.backoffStep = 0;
       state = {
         mode,
         likeCount: likeCount || 0,
         cfg: { ...DEFAULT_CFG, ...(cfg || {}) },
       };
-      running = true;
-      backoffStep = 0;
-      log('start', queue.length, mode);
-      scheduleNext(0, 'waiting', { nextDelayMs: 0 });
+      scheduleNext(0);
       sendResponse({ ok: true });
     });
     return true;
   } else if (msg.type === 'STOP_QUEUE') {
-    stop();
+    stopQueue();
     sendResponse({ ok: true });
   } else if (msg.type === 'CFG_UPDATED') {
     cachedCfg = { ...cachedCfg, ...(msg.cfg || {}) };
@@ -60,17 +66,167 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
 });
 
-function stop() {
-  running = false;
-  queue = [];
-  if (timer) {
-    clearTimeout(timer);
-    timer = null;
+function stopQueue() {
+  q.isRunning = false;
+  clearTimeout(q.timer);
+  q.timer = null;
+  q.nextActionAt = null;
+  q.phase = 'paused';
+  emitTick();
+}
+
+function postToPanel(message) {
+  if (activeTabId) {
+    chrome.tabs.sendMessage(activeTabId, message);
   }
-  nextActionAt = null;
-  lock = false;
-  backoffStep = 0;
-  emitTick('paused');
+}
+
+function computeNextDelayMs(cfg) {
+  const base = parseInt(cfg.baseDelayMs, 10) || 0;
+  const jitterPct = parseInt(cfg.jitterPct, 10) || 0;
+  const jitter = ((base * jitterPct) / 100) * (Math.random() * 2 - 1);
+  return Math.max(0, Math.round(base + jitter));
+}
+
+function computeBackoffMs() {
+  const base = parseInt(state.cfg.baseDelayMs, 10) || 1000;
+  const ms = Math.min(60000, base * Math.pow(2, q.backoffStep));
+  q.backoffStep++;
+  return ms;
+}
+
+function resetBackoff() {
+  q.backoffStep = 0;
+}
+
+function emitTick(extra = {}) {
+  postToPanel({
+    type: 'QUEUE_TICK',
+    processed: q.processed,
+    total: q.total,
+    phase: q.phase,
+    nextActionAt: q.nextActionAt,
+    current: q.items[q.idx] || null,
+    ...extra,
+  });
+}
+
+function scheduleNext(waitMs) {
+  q.phase = 'waiting';
+  q.nextActionAt = Date.now() + waitMs;
+  clearTimeout(q.timer);
+  emitTick({ nextDelayMs: waitMs });
+  q.timer = setTimeout(startAction, waitMs);
+}
+
+async function startAction() {
+  if (q.idx >= q.total) {
+    finishQueue();
+    return;
+  }
+  q.phase = 'executing';
+  emitTick();
+  const item = q.items[q.idx];
+  const resp = await execWithTimeout(item);
+  handleResult(resp);
+}
+
+async function execWithTimeout(item) {
+  let transient = false;
+  let lastStatus = {};
+  try {
+    if (state.mode === 'follow' || state.mode === 'follow_like') {
+      const res = await execCommand(activeTabId, 'FOLLOW', {
+        userId: item.id,
+        username: item.username,
+      });
+      postToPanel({
+        type: 'ROW_UPDATE',
+        index: q.idx,
+        id: item.id,
+        status: { followed: !!res?.ok, error: res?.ok ? undefined : res?.error },
+      });
+      if (!res?.ok) throw new Error(res.error || 'follow_failed');
+      lastStatus.followed = true;
+    }
+    if (state.mode === 'follow_like') {
+      const totalLikes = state.likeCount || 0;
+      for (let i = 0; i < totalLikes; i++) {
+        const r = await execCommand(activeTabId, 'LIKE', {
+          userId: item.id,
+          username: item.username,
+        });
+        postToPanel({
+          type: 'ROW_UPDATE',
+          index: q.idx,
+          id: item.id,
+          status: {
+            likesTotal: totalLikes,
+            likesDone: i + 1,
+            error: r?.ok ? undefined : r?.error,
+          },
+        });
+        if (!r?.ok) throw new Error(r.error || 'like_failed');
+        lastStatus = { likesTotal: totalLikes, likesDone: i + 1 };
+      }
+    }
+    if (state.mode === 'unfollow') {
+      const r = await execCommand(activeTabId, 'UNFOLLOW', {
+        userId: item.id,
+        username: item.username,
+      });
+      postToPanel({
+        type: 'ROW_UPDATE',
+        index: q.idx,
+        id: item.id,
+        status: { unfollowed: !!r?.ok, error: r?.ok ? undefined : r?.error },
+      });
+      if (!r?.ok) throw new Error(r.error || 'unfollow_failed');
+      lastStatus.unfollowed = true;
+    }
+    resetBackoff();
+    return { ok: true, status: lastStatus };
+  } catch (e) {
+    const err = String(e.message || e);
+    transient = isTransientError(err);
+    return { ok: false, error: err, transient };
+  }
+}
+
+function handleResult(resp) {
+  const item = q.items[q.idx];
+  const status = resp.status || (resp.ok ? {} : { error: resp.error });
+  postToPanel({ type: 'ROW_UPDATE', index: q.idx, id: item.id, status });
+  q.processed++;
+  q.idx++;
+  if (q.idx >= q.total) {
+    finishQueue();
+    return;
+  }
+  if (resp.transient) {
+    q.phase = 'backoff';
+    const ms = computeBackoffMs();
+    q.nextActionAt = Date.now() + ms;
+    clearTimeout(q.timer);
+    emitTick({ backoffMs: ms });
+    q.timer = setTimeout(() => scheduleNext(computeNextDelayMs(state.cfg)), ms);
+  } else {
+    scheduleNext(computeNextDelayMs(state.cfg));
+  }
+}
+
+function finishQueue() {
+  q.phase = 'done';
+  clearTimeout(q.timer);
+  q.timer = null;
+  q.nextActionAt = null;
+  emitTick();
+  postToPanel({ type: 'QUEUE_DONE', processed: q.processed, total: q.total });
+  q.isRunning = false;
+}
+
+function isTransientError(err) {
+  return /429|rate|timeout|temporarily/i.test(err);
 }
 
 function sendToTab(tabId, message, timeoutMs = 5000) {
@@ -101,137 +257,4 @@ async function execCommand(tabId, action, payload) {
   }
   log('exec', action, payload);
   return sendToTab(tabId, { type: 'EXEC_TASK', action, payload });
-}
-async function runNext() {
-  if (!running || lock) return;
-  if (!queue.length) {
-    finish();
-    return;
-  }
-  lock = true;
-  const item = queue.shift();
-  emitTick('executing', { current: { id: item.id, username: item.username } });
-  let transient = false;
-  try {
-    if (state.mode === 'follow' || state.mode === 'follow_like') {
-      const res = await execCommand(activeTabId, 'FOLLOW', {
-        userId: item.id,
-        username: item.username,
-      });
-      chrome.tabs.sendMessage(activeTabId, {
-        type: 'ROW_UPDATE',
-        id: item.id,
-        status: { followed: !!res?.ok, error: res?.ok ? undefined : res?.error },
-      });
-      if (!res?.ok) throw new Error(res.error || 'follow_failed');
-    }
-    if (state.mode === 'follow_like') {
-      const totalLikes = state.likeCount || 0;
-      for (let i = 0; i < totalLikes; i++) {
-        const r = await execCommand(activeTabId, 'LIKE', {
-          userId: item.id,
-          username: item.username,
-        });
-        chrome.tabs.sendMessage(activeTabId, {
-          type: 'ROW_UPDATE',
-          id: item.id,
-          status: {
-            likesTotal: totalLikes,
-            likesDone: i + 1,
-            error: r?.ok ? undefined : r?.error,
-          },
-        });
-        if (!r?.ok) throw new Error(r.error || 'like_failed');
-      }
-    }
-    if (state.mode === 'unfollow') {
-      const r = await execCommand(activeTabId, 'UNFOLLOW', {
-        userId: item.id,
-        username: item.username,
-      });
-      chrome.tabs.sendMessage(activeTabId, {
-        type: 'ROW_UPDATE',
-        id: item.id,
-        status: { unfollowed: !!r?.ok, error: r?.ok ? undefined : r?.error },
-      });
-      if (!r?.ok) throw new Error(r.error || 'unfollow_failed');
-    }
-    resetBackoff();
-  } catch (e) {
-    const err = String(e.message || e);
-    chrome.tabs.sendMessage(activeTabId, {
-      type: 'ROW_UPDATE',
-      id: item.id,
-      status: { error: err },
-    });
-    transient = isTransientError(err);
-  }
-  processed++;
-  lock = false;
-  if (!running) return;
-  if (queue.length === 0) {
-    finish();
-    return;
-  }
-  if (transient) {
-    const backoffMs = calcBackoff();
-    scheduleNext(backoffMs, 'backoff', { backoffMs });
-  } else {
-    const delay = nextDelay();
-    scheduleNext(delay, 'waiting', { nextDelayMs: delay });
-  }
-}
-
-function nextDelay() {
-  const base = parseInt(state.cfg.baseDelayMs, 10) || 0;
-  const jitterPct = parseInt(state.cfg.jitterPct, 10) || 0;
-  const jitter = ((base * jitterPct) / 100) * (Math.random() * 2 - 1);
-  return Math.max(0, Math.round(base + jitter));
-}
-
-function calcBackoff() {
-  const base = parseInt(state.cfg.baseDelayMs, 10) || 1000;
-  const ms = Math.min(60000, base * Math.pow(2, backoffStep));
-  backoffStep++;
-  return ms;
-}
-
-function resetBackoff() {
-  backoffStep = 0;
-}
-
-function isTransientError(err) {
-  return /429|rate|timeout|temporarily/i.test(err);
-}
-
-function scheduleNext(delay, phase, extra = {}) {
-  if (timer) clearTimeout(timer);
-  nextActionAt = Date.now() + delay;
-  timer = setTimeout(runNext, delay);
-  emitTick(phase, { ...extra, nextActionAt });
-}
-
-function emitTick(phase, extra = {}) {
-  if (!activeTabId) return;
-  chrome.tabs.sendMessage(activeTabId, {
-    type: 'QUEUE_TICK',
-    processed,
-    total,
-    phase,
-    ...extra,
-  });
-}
-
-function finish() {
-  running = false;
-  timer = null;
-  nextActionAt = null;
-  emitTick('done');
-  if (activeTabId) {
-    chrome.tabs.sendMessage(activeTabId, {
-      type: 'QUEUE_DONE',
-      processed,
-      total,
-    });
-  }
 }

--- a/panel.js
+++ b/panel.js
@@ -41,7 +41,7 @@ window.__IG_PANEL_MSG_HANDLER = (ev) => {
     const row = followers.find((f) => f.id === msg.id);
     if (row) {
       row.status = { ...(row.status || {}), ...msg.status };
-      renderTable();
+      updateRow(msg.id);
     }
   } else if (msg.type === 'QUEUE_TICK') {
     ov.processed = msg.processed || 0;
@@ -64,15 +64,6 @@ window.__IG_PANEL_MSG_HANDLER = (ev) => {
     }
   } else if (msg.type === 'QUEUE_DONE') {
     running = false;
-    ov.processed = msg.processed || ov.processed;
-    ov.total = msg.total || ov.total;
-    ov.phase = 'done';
-    ov.nextActionAt = null;
-    qs('#rsx-prog').textContent = `${ov.processed} / ${ov.total}`;
-    qs('#rsx-phase').textContent = ov.phase;
-    clearInterval(ovTimer);
-    ovTimer = null;
-    tickOverlay();
     updateRunButtons();
   }
 };
@@ -201,6 +192,7 @@ function renderTable() {
   }
   for (const f of list) {
     const tr = document.createElement('tr');
+    tr.dataset.id = String(f.id);
     const tdChk = document.createElement('td');
     const chk = document.createElement('input');
     chk.type = 'checkbox';
@@ -212,11 +204,21 @@ function renderTable() {
     const tdUser = document.createElement('td');
     tdUser.textContent = '@' + f.username;
     const tdStatus = document.createElement('td');
+    tdStatus.className = 'status';
     tdStatus.innerHTML = renderStatus(f.status);
     tr.appendChild(tdChk);
     tr.appendChild(tdUser);
     tr.appendChild(tdStatus);
     body.appendChild(tr);
+  }
+}
+
+function updateRow(id) {
+  const rowEl = qs(`#queueTable tbody tr[data-id="${id}"]`);
+  if (rowEl) {
+    const st = followers.find((f) => f.id === id)?.status;
+    const tdStatus = rowEl.querySelector('td.status');
+    if (tdStatus) tdStatus.innerHTML = renderStatus(st);
   }
 }
 


### PR DESCRIPTION
## Summary
- implement centralized scheduler in service worker with delay/backoff logic and transition events
- update panel to patch only affected row and refresh overlay on queue ticks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b6076cd84083268ceead6ebf49b2ef