### PR TITLE
feat: precheck already followed

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -60,9 +60,13 @@ if (window.__IG_CS_TASK_HANDLER) {
       );
       return true;
     } else if (
-      ['ROW_UPDATE', 'QUEUE_TICK', 'QUEUE_DONE', 'FOLLOWERS_LOADED'].includes(
-        msg.type,
-      )
+      [
+        'ROW_UPDATE',
+        'QUEUE_TICK',
+        'QUEUE_DONE',
+        'FOLLOWERS_LOADED',
+        'PRECHECK_REMOVED',
+      ].includes(msg.type)
     ) {
       window.postMessage(msg, '*');
     }

--- a/igClient.js
+++ b/igClient.js
@@ -154,13 +154,14 @@ export class IGClient {
     };
   }
 
-  async getFriendshipStatusBulk(userIds = []) {
+  async getFriendshipStatusBulk(userIds = [], opts = {}) {
+    const { forceFresh = false } = opts;
     const res = {};
     const now = Date.now();
     const toQuery = [];
     for (const id of userIds) {
       const cached = this._relCache.get(id);
-      if (cached && now - cached.ts < this._relTtlMs) {
+      if (!forceFresh && cached && now - cached.ts < this._relTtlMs) {
         res[id] = {
           following: !!cached.following,
           followed_by: !!cached.followed_by,

--- a/runner.js
+++ b/runner.js
@@ -182,7 +182,10 @@ export class IGRunner {
       case "LIST_FOLLOWING":
         return await this.ig.listFollowing(task);
       case "FRIENDSHIP_STATUS_BULK":
-        return await this.ig.getFriendshipStatusBulk(task.ids || task.userIds || []);
+        return await this.ig.getFriendshipStatusBulk(
+          task.ids || task.userIds || [],
+          { forceFresh: !!task.forceFresh },
+        );
       default:
         throw new Error("unknown_task");
     }


### PR DESCRIPTION
## Summary
- support force-fresh bulk friendship lookups and caching
- drop already-followed users before queue starts via precheck window
- show removed entries in panel and keep progress counts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7682c69ec8326a2fe65f8fedeee4e