### PR TITLE
Implement strict not-following user pipeline

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -14,6 +14,7 @@ let running = false;
 let ov = { processed: 0, total: 0, phase: 'idle', nextActionAt: null };
 let ovTimer = null;
 let totalRemovedAlreadyFollowing = 0;
+let totalUnknown = 0;
 
 function send(msg) {
   window.postMessage({ from: 'ig-panel', ...msg }, '*');
@@ -38,6 +39,7 @@ window.__IG_PANEL_MSG_HANDLER = (ev) => {
     followers = msg.items || [];
     page = 1;
     totalRemovedAlreadyFollowing = msg.removedAlreadyFollowing || 0;
+    totalUnknown = msg.unknownTotal || 0;
     renderTable();
     updatePager();
     updateCollectProgress();
@@ -83,7 +85,8 @@ window.__IG_PANEL_MSG_HANDLER = (ev) => {
     updateRunButtons();
   } else if (msg.type === 'COLLECT_PROGRESS') {
     totalRemovedAlreadyFollowing = msg.removedAlreadyFollowing || 0;
-    qs('#collectProgress').textContent = `Coletados ${msg.total}/${msg.target} (removidos ${totalRemovedAlreadyFollowing} já seguidos)`;
+    totalUnknown = msg.unknownTotal || 0;
+    qs('#collectProgress').textContent = `Removidos: ${totalRemovedAlreadyFollowing} | Ignorados (desconhecidos): ${totalUnknown} | Mantidos: ${msg.totalKept}/${msg.target}`;
   }
 };
 window.addEventListener('message', window.__IG_PANEL_MSG_HANDLER);
@@ -93,7 +96,7 @@ window.__IG_PANEL_CLEANUP = () => {
 };
 
 function updateCollectProgress() {
-  qs('#collectProgress').textContent = `Coletados ${followers.length}/${followers.length + totalRemovedAlreadyFollowing} (removidos ${totalRemovedAlreadyFollowing} já seguidos)`;
+  qs('#collectProgress').textContent = `Removidos: ${totalRemovedAlreadyFollowing} | Ignorados (desconhecidos): ${totalUnknown} | Mantidos: ${followers.length}/${followers.length + totalRemovedAlreadyFollowing + totalUnknown}`;
 }
 
 function init() {

--- a/runner.js
+++ b/runner.js
@@ -199,7 +199,7 @@ export class IGRunner {
         const toCheck = [];
         for (const id of ids) {
           if (followIndex.hasId(id)) {
-            res[id] = { following: true, followed_by: false };
+            res[id] = { following: true, resolved: true };
           } else {
             toCheck.push(id);
           }


### PR DESCRIPTION
## Summary
- ensure friendship bulk API returns `resolved` state and retries with backoff
- filter batches strictly to only not-following users and double-check unknowns
- show removed and unknown counts in progress overlay

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b779d7e47483269de2a70de6c46524