### PR TITLE
Refactor queue alarms and watchdog handling

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -3,7 +3,7 @@ const DEFAULT_CFG = {
   jitterPct: 20,
   pageSize: 10,
   likePerProfile: 1,
-  actionModeDefault: 'follow_like',
+  actionModeDefault: "follow_like",
   includeAlreadyFollowing: false,
 };
 let cfg = { ...DEFAULT_CFG };
@@ -14,7 +14,7 @@ let running = false;
 let ov = {
   processed: 0,
   total: 0,
-  phase: 'idle',
+  phase: "idle",
   nextActionAt: null,
   reason: null,
   strikes: 0,
@@ -25,7 +25,7 @@ let totalUnknown = 0;
 let isMinimized = false;
 
 function send(msg) {
-  window.postMessage({ from: 'ig-panel', ...msg }, '*');
+  window.postMessage({ from: "ig-panel", ...msg }, "*");
 }
 
 function qs(sel) {
@@ -33,13 +33,13 @@ function qs(sel) {
 }
 
 if (window.__IG_PANEL_MSG_HANDLER) {
-  window.removeEventListener('message', window.__IG_PANEL_MSG_HANDLER);
+  window.removeEventListener("message", window.__IG_PANEL_MSG_HANDLER);
 }
 window.__IG_PANEL_MSG_HANDLER = (ev) => {
   const msg = ev.data || {};
-  if (msg.type === 'PANEL_READY') {
+  if (msg.type === "PANEL_READY") {
     init();
-  } else if (msg.type === 'FOLLOWERS_LOADED') {
+  } else if (msg.type === "FOLLOWERS_LOADED") {
     if (msg.error) {
       alert(msg.error);
       return;
@@ -51,35 +51,34 @@ window.__IG_PANEL_MSG_HANDLER = (ev) => {
     renderTable();
     updatePager();
     updateCollectProgress();
-  } else if (msg.type === 'ROW_UPDATE') {
+  } else if (msg.type === "ROW_UPDATE") {
     const row = followers.find((f) => f.id === msg.id);
     if (row) {
       row.status = { ...(row.status || {}), ...msg.status };
       renderTable();
     }
-  } else if (msg.type === 'PRECHECK_REMOVED') {
+  } else if (msg.type === "PRECHECK_REMOVED") {
     totalRemovedAlreadyFollowing += msg.removed || 0;
     updateCollectProgress();
-  } else if (msg.type === 'QUEUE_TICK') {
+  } else if (msg.type === "QUEUE_TICK") {
     ov.processed = msg.processed || 0;
     ov.total = msg.total || 0;
-    ov.phase = msg.phase || 'idle';
+    ov.phase = msg.phase || "idle";
     ov.nextActionAt = msg.nextActionAt || null;
     ov.reason = msg.reason;
     ov.strikes = msg.strikes;
-    qs('#rsx-prog').textContent = `${ov.processed} / ${ov.total}`;
-    if (ov.phase === 'backoff' && ov.reason === 'feedback_required') {
-      qs('#rsx-phase').textContent = `Pausa de segurança (feedback_required) • strikes: ${
-        ov.strikes || 0
-      }`;
+    qs("#rsx-prog").textContent = `${ov.processed} / ${ov.total}`;
+    if (ov.phase === "backoff" && ov.reason === "feedback_required") {
+      qs("#rsx-phase").textContent =
+        `Pausa de segurança (feedback_required) • strikes: ${ov.strikes || 0}`;
     } else {
-      qs('#rsx-phase').textContent = ov.phase;
+      qs("#rsx-phase").textContent = ov.phase;
     }
     tickOverlay();
-    if (!ovTimer && ov.phase !== 'done' && ov.phase !== 'paused') {
+    if (!ovTimer && ov.phase !== "done" && ov.phase !== "idle") {
       ovTimer = setInterval(tickOverlay, 200);
     }
-    if (ov.phase === 'done' || ov.phase === 'paused') {
+    if (ov.phase === "done" || ov.phase === "idle") {
       running = false;
       clearInterval(ovTimer);
       ovTimer = null;
@@ -87,23 +86,24 @@ window.__IG_PANEL_MSG_HANDLER = (ev) => {
       tickOverlay();
       updateRunButtons();
     }
-  } else if (msg.type === 'QUEUE_DONE') {
+  } else if (msg.type === "QUEUE_DONE") {
     running = false;
     ov.processed = msg.processed || ov.processed;
     ov.total = msg.total || ov.total;
-    ov.phase = 'done';
+    ov.phase = "done";
     ov.nextActionAt = null;
-    qs('#rsx-prog').textContent = `${ov.processed} / ${ov.total}`;
-    qs('#rsx-phase').textContent = ov.phase;
+    qs("#rsx-prog").textContent = `${ov.processed} / ${ov.total}`;
+    qs("#rsx-phase").textContent = ov.phase;
     clearInterval(ovTimer);
     ovTimer = null;
     tickOverlay();
     updateRunButtons();
-  } else if (msg.type === 'COLLECT_PROGRESS') {
+  } else if (msg.type === "COLLECT_PROGRESS") {
     totalRemovedAlreadyFollowing = msg.removedAlreadyFollowing || 0;
     totalUnknown = msg.unknownTotal || 0;
-    qs('#collectProgress').textContent = `Removidos: ${totalRemovedAlreadyFollowing} | Ignorados (desconhecidos): ${totalUnknown} | Mantidos: ${msg.totalKept}/${msg.target}`;
-  } else if (msg.type === 'QUEUE_RESET') {
+    qs("#collectProgress").textContent =
+      `Removidos: ${totalRemovedAlreadyFollowing} | Ignorados (desconhecidos): ${totalUnknown} | Mantidos: ${msg.totalKept}/${msg.target}`;
+  } else if (msg.type === "QUEUE_RESET") {
     running = false;
     followers = [];
     page = 1;
@@ -112,13 +112,13 @@ window.__IG_PANEL_MSG_HANDLER = (ev) => {
     ov = {
       processed: 0,
       total: 0,
-      phase: 'idle',
+      phase: "idle",
       nextActionAt: null,
       reason: null,
       strikes: 0,
     };
-    qs('#rsx-prog').textContent = '0 / 0';
-    qs('#rsx-phase').textContent = 'idle';
+    qs("#rsx-prog").textContent = "0 / 0";
+    qs("#rsx-phase").textContent = "idle";
     tickOverlay();
     renderTable();
     updatePager();
@@ -126,70 +126,74 @@ window.__IG_PANEL_MSG_HANDLER = (ev) => {
     updateRunButtons();
   }
 };
-window.addEventListener('message', window.__IG_PANEL_MSG_HANDLER);
+window.addEventListener("message", window.__IG_PANEL_MSG_HANDLER);
 window.__IG_PANEL_CLEANUP = () => {
-  window.removeEventListener('message', window.__IG_PANEL_MSG_HANDLER);
+  window.removeEventListener("message", window.__IG_PANEL_MSG_HANDLER);
   window.__IG_PANEL_MSG_HANDLER = null;
 };
 
 function updateCollectProgress() {
-  qs('#collectProgress').textContent = `Removidos: ${totalRemovedAlreadyFollowing} | Ignorados (desconhecidos): ${totalUnknown} | Mantidos: ${followers.length}/${followers.length + totalRemovedAlreadyFollowing + totalUnknown}`;
+  qs("#collectProgress").textContent =
+    `Removidos: ${totalRemovedAlreadyFollowing} | Ignorados (desconhecidos): ${totalUnknown} | Mantidos: ${followers.length}/${followers.length + totalRemovedAlreadyFollowing + totalUnknown}`;
 }
 
 function init() {
   bindTabs();
-  qs('#btnLoadFollowers').addEventListener('click', () => {
-    const limit = parseInt(qs('#limit').value, 10) || 0;
-    send({ type: 'LOAD_FOLLOWERS', limit });
+  qs("#btnLoadFollowers").addEventListener("click", () => {
+    const limit = parseInt(qs("#limit").value, 10) || 0;
+    send({ type: "LOAD_FOLLOWERS", limit });
   });
-  qs('#btnLoadFollowing').addEventListener('click', () => {
-    const limit = parseInt(qs('#limit').value, 10) || 0;
-    send({ type: 'LOAD_FOLLOWING', limit });
+  qs("#btnLoadFollowing").addEventListener("click", () => {
+    const limit = parseInt(qs("#limit").value, 10) || 0;
+    send({ type: "LOAD_FOLLOWING", limit });
   });
-  qs('#btnProcess').addEventListener('click', () => {
-    toggleMenu('#processMenu');
+  qs("#btnProcess").addEventListener("click", () => {
+    toggleMenu("#processMenu");
   });
-  qs('#btnLoad').addEventListener('click', () => {
-    toggleMenu('#loadMenu');
+  qs("#btnLoad").addEventListener("click", () => {
+    toggleMenu("#loadMenu");
   });
-  qs('#btnProcessConfirm').addEventListener('click', () => {
+  qs("#btnProcessConfirm").addEventListener("click", () => {
     startProcessing();
-    qs('#processMenu').style.display = 'none';
+    qs("#processMenu").style.display = "none";
   });
-  qs('#btnClearQueue').addEventListener('click', () => {
-    if (confirm('Remover a fila atual? Isso limpa a tabela e zera o progresso.')) {
-      send({ type: 'RESET_QUEUE' });
+  qs("#btnClearQueue").addEventListener("click", () => {
+    if (
+      confirm("Remover a fila atual? Isso limpa a tabela e zera o progresso.")
+    ) {
+      send({ type: "RESET_QUEUE" });
     }
   });
-  qs('#btnMinimize').addEventListener('click', () => minimizePanel());
-  qs('#btnRestore').addEventListener('click', () => restorePanel());
-  qs('#btnStart').addEventListener('click', startProcessing);
-  qs('#btnStop').addEventListener('click', stopProcessing);
-  qs('#pageSize').addEventListener('change', () => {
-    pageSize = parseInt(qs('#pageSize').value, 10);
+  qs("#btnMinimize").addEventListener("click", () => minimizePanel());
+  qs("#btnRestore").addEventListener("click", () => restorePanel());
+  qs("#btnStart").addEventListener("click", startProcessing);
+  qs("#btnStop").addEventListener("click", stopProcessing);
+  qs("#pageSize").addEventListener("change", () => {
+    pageSize = parseInt(qs("#pageSize").value, 10);
     cfg.pageSize = pageSize;
     saveCfg();
     renderTable();
     updatePager();
   });
-  qs('#cfgPageSize').addEventListener('change', () => {
-    cfg.pageSize = parseInt(qs('#cfgPageSize').value, 10) || DEFAULT_CFG.pageSize;
+  qs("#cfgPageSize").addEventListener("change", () => {
+    cfg.pageSize =
+      parseInt(qs("#cfgPageSize").value, 10) || DEFAULT_CFG.pageSize;
     pageSize = cfg.pageSize;
     saveCfg();
-    qs('#pageSize').value = String(pageSize);
+    qs("#pageSize").value = String(pageSize);
     renderTable();
     updatePager();
   });
-  qs('#likeCount').addEventListener('input', handleLikeInput);
-  qs('#cfgSave').addEventListener('click', saveCfgFromInputs);
-  qs('#prevPage').addEventListener('click', () => {
+  qs("#likeCount").addEventListener("input", handleLikeInput);
+  qs("#cfgSave").addEventListener("click", saveCfgFromInputs);
+  qs("#prevPage").addEventListener("click", () => {
     if (page > 1) {
       page--;
       renderTable();
       updatePager();
     }
   });
-  qs('#nextPage').addEventListener('click', () => {
+  qs("#nextPage").addEventListener("click", () => {
     const totalPages = getTotalPages();
     if (page < totalPages) {
       page++;
@@ -197,7 +201,7 @@ function init() {
       updatePager();
     }
   });
-  qs('#chkAll').addEventListener('change', (e) => {
+  qs("#chkAll").addEventListener("change", (e) => {
     followers.forEach((f) => (f.checked = e.target.checked));
     renderTable();
   });
@@ -206,8 +210,11 @@ function init() {
   chrome.storage.session.get({ panelMinimized: false }, (st) => {
     if (st.panelMinimized) minimizePanel(true);
   });
-  window.addEventListener('keydown', (e) => {
-    if (e.key?.toLowerCase() === 'm' && !['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {
+  window.addEventListener("keydown", (e) => {
+    if (
+      e.key?.toLowerCase() === "m" &&
+      !["INPUT", "TEXTAREA"].includes(e.target.tagName)
+    ) {
       if (isMinimized) {
         restorePanel();
       } else {
@@ -218,19 +225,23 @@ function init() {
 }
 
 function bindTabs() {
-  document.querySelectorAll('.tab-btn').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      document.querySelectorAll('.tab-btn').forEach((b) => b.classList.remove('active'));
-      document.querySelectorAll('.tab-content').forEach((c) => c.classList.remove('active'));
-      btn.classList.add('active');
-      qs(`#tab-${btn.dataset.tab}`).classList.add('active');
+  document.querySelectorAll(".tab-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      document
+        .querySelectorAll(".tab-btn")
+        .forEach((b) => b.classList.remove("active"));
+      document
+        .querySelectorAll(".tab-content")
+        .forEach((c) => c.classList.remove("active"));
+      btn.classList.add("active");
+      qs(`#tab-${btn.dataset.tab}`).classList.add("active");
     });
   });
 }
 
 function toggleMenu(sel) {
   const m = qs(sel);
-  m.style.display = m.style.display === 'block' ? 'none' : 'block';
+  m.style.display = m.style.display === "block" ? "none" : "block";
 }
 
 function startProcessing() {
@@ -239,24 +250,24 @@ function startProcessing() {
   const list = selected.length ? selected : followers;
   const targets = list.map((u) => ({ id: u.id, username: u.username }));
   const mode = document.querySelector('input[name="actionMode"]:checked').value;
-  const likeCount = parseInt(qs('#likeCount').value, 10) || 0;
+  const likeCount = parseInt(qs("#likeCount").value, 10) || 0;
   const cfgSnapshot = getCurrentCfg();
-  send({ type: 'START_QUEUE', mode, likeCount, targets, cfg: cfgSnapshot });
+  send({ type: "START_QUEUE", mode, likeCount, targets, cfg: cfgSnapshot });
   running = true;
   updateRunButtons();
 }
 
 function stopProcessing() {
-  send({ type: 'STOP_QUEUE' });
+  send({ type: "STOP_QUEUE" });
   running = false;
   updateRunButtons();
 }
 
 function updateRunButtons() {
-  qs('#btnStart').disabled = running;
-  qs('#btnProcess').disabled = running;
-  qs('#btnLoad').disabled = running;
-  qs('#btnStop').disabled = !running;
+  qs("#btnStart").disabled = running;
+  qs("#btnProcess").disabled = running;
+  qs("#btnLoad").disabled = running;
+  qs("#btnStop").disabled = !running;
 }
 
 function getTotalPages() {
@@ -265,26 +276,26 @@ function getTotalPages() {
 }
 
 function renderTable() {
-  const body = qs('#queueTable tbody');
-  body.innerHTML = '';
+  const body = qs("#queueTable tbody");
+  body.innerHTML = "";
   let list = followers;
   if (pageSize !== 0) {
     const start = (page - 1) * pageSize;
     list = followers.slice(start, start + pageSize);
   }
   for (const f of list) {
-    const tr = document.createElement('tr');
-    const tdChk = document.createElement('td');
-    const chk = document.createElement('input');
-    chk.type = 'checkbox';
+    const tr = document.createElement("tr");
+    const tdChk = document.createElement("td");
+    const chk = document.createElement("input");
+    chk.type = "checkbox";
     chk.checked = !!f.checked;
-    chk.addEventListener('change', () => {
+    chk.addEventListener("change", () => {
       f.checked = chk.checked;
     });
     tdChk.appendChild(chk);
-    const tdUser = document.createElement('td');
-    tdUser.textContent = '@' + f.username;
-    const tdStatus = document.createElement('td');
+    const tdUser = document.createElement("td");
+    tdUser.textContent = "@" + f.username;
+    const tdStatus = document.createElement("td");
     tdStatus.innerHTML = renderStatus(f);
     tr.appendChild(tdChk);
     tr.appendChild(tdUser);
@@ -299,30 +310,30 @@ function renderStatus(f) {
   if (f.rel?.following) return '<span class="badge info">Já seguia</span>';
   if (st?.removedAlreadyFollowing)
     return '<span class="badge info">Já seguia (removido)</span>';
-  if (st?.alreadyFollowing || st?.result === 'already_following')
+  if (st?.alreadyFollowing || st?.result === "already_following")
     return '<span class="badge info">Já seguia</span>';
-  if (!st) return '';
+  if (!st) return "";
   if (st.error) return `<span class="badge error">${st.error}</span>`;
   if (st.likesTotal)
     return `<span class="badge wait">Likes: ${st.likesDone || 0}/${st.likesTotal}</span>`;
   if (st.followed || st.unfollowed)
     return '<span class="badge success">Seguido</span>';
-  return '';
+  return "";
 }
 
 function updatePager() {
-  qs('#pageInfo').textContent = `${page}/${getTotalPages()}`;
-  qs('#pageSize').value = String(pageSize);
+  qs("#pageInfo").textContent = `${page}/${getTotalPages()}`;
+  qs("#pageSize").value = String(pageSize);
 }
 
 function tickOverlay() {
-  const etaEl = qs('#rsx-eta');
-  const miniEtaEl = qs('#miniEta');
-  const miniProgEl = qs('#miniProg');
+  const etaEl = qs("#rsx-eta");
+  const miniEtaEl = qs("#miniEta");
+  const miniProgEl = qs("#miniProg");
   if (miniProgEl) miniProgEl.textContent = `${ov.processed}/${ov.total}`;
   if (!ov.nextActionAt) {
-    etaEl.textContent = '--:--.-';
-    if (miniEtaEl) miniEtaEl.textContent = '--:--';
+    etaEl.textContent = "--:--.-";
+    if (miniEtaEl) miniEtaEl.textContent = "--:--";
     return;
   }
   const rem = Math.max(0, ov.nextActionAt - Date.now());
@@ -330,70 +341,76 @@ function tickOverlay() {
     const h = Math.floor(rem / 3600000);
     const m = Math.floor((rem % 3600000) / 60000);
     const s = Math.floor((rem % 60000) / 1000);
-    const txt = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    const txt = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
     etaEl.textContent = txt;
     if (miniEtaEl) miniEtaEl.textContent = txt;
   } else {
     const m = Math.floor(rem / 60000);
     const s = Math.floor((rem % 60000) / 1000);
     const d = Math.floor((rem % 1000) / 100);
-    etaEl.textContent = `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}.${d}`;
+    etaEl.textContent = `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}.${d}`;
     if (miniEtaEl)
-      miniEtaEl.textContent = `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+      miniEtaEl.textContent = `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
   }
 }
 
 function minimizePanel(skipSave = false) {
-  qs('#panel').style.display = 'none';
-  qs('#panel-mini').style.display = 'flex';
+  qs("#panel").style.display = "none";
+  qs("#panel-mini").style.display = "flex";
   isMinimized = true;
   tickOverlay();
   if (!skipSave) chrome.storage.session.set({ panelMinimized: true });
 }
 
 function restorePanel(skipSave = false) {
-  qs('#panel').style.display = 'block';
-  qs('#panel-mini').style.display = 'none';
+  qs("#panel").style.display = "block";
+  qs("#panel-mini").style.display = "none";
   isMinimized = false;
   tickOverlay();
   if (!skipSave) chrome.storage.session.set({ panelMinimized: false });
 }
 function handleLikeInput() {
-  const v = parseInt(qs('#likeCount').value, 10) || 0;
-  const radio = qs('#modeFollowLike');
+  const v = parseInt(qs("#likeCount").value, 10) || 0;
+  const radio = qs("#modeFollowLike");
   radio.disabled = v <= 0;
-  if (v <= 0 && radio.checked) qs('#modeFollow').checked = true;
+  if (v <= 0 && radio.checked) qs("#modeFollow").checked = true;
 }
 
 function getCurrentCfg() {
-  const delaySec = parseFloat(qs('#cfgDelayMs').value);
+  const delaySec = parseFloat(qs("#cfgDelayMs").value);
   return {
-    baseDelayMs:
-      delaySec ? delaySec * 1000 : cfg.baseDelayMs || DEFAULT_CFG.baseDelayMs,
-    jitterPct: +qs('#cfgJitterPct').value || cfg.jitterPct || DEFAULT_CFG.jitterPct,
+    baseDelayMs: delaySec
+      ? delaySec * 1000
+      : cfg.baseDelayMs || DEFAULT_CFG.baseDelayMs,
+    jitterPct:
+      +qs("#cfgJitterPct").value || cfg.jitterPct || DEFAULT_CFG.jitterPct,
     pageSize: cfg.pageSize || DEFAULT_CFG.pageSize,
     likePerProfile:
-      +qs('#cfgLikePerProfile').value || cfg.likePerProfile || DEFAULT_CFG.likePerProfile,
+      +qs("#cfgLikePerProfile").value ||
+      cfg.likePerProfile ||
+      DEFAULT_CFG.likePerProfile,
     actionModeDefault:
-      qs('#cfgMode').value || cfg.actionModeDefault || DEFAULT_CFG.actionModeDefault,
-    includeAlreadyFollowing: qs('#cfgIncludeAlreadyFollowing').checked,
+      qs("#cfgMode").value ||
+      cfg.actionModeDefault ||
+      DEFAULT_CFG.actionModeDefault,
+    includeAlreadyFollowing: qs("#cfgIncludeAlreadyFollowing").checked,
   };
 }
 
 function saveCfgFromInputs() {
   cfg = getCurrentCfg();
   saveCfg();
-  qs('#likeCount').value = String(cfg.likePerProfile);
-  qs('#cfgPageSize').value = cfg.pageSize;
-  qs('#pageSize').value = String(cfg.pageSize);
-  qs('#cfgDelayMs').value = cfg.baseDelayMs / 1000;
-  qs('#cfgJitterPct').value = cfg.jitterPct;
-  qs('#cfgLikePerProfile').value = cfg.likePerProfile;
-  qs('#cfgMode').value = cfg.actionModeDefault;
-  qs('#cfgIncludeAlreadyFollowing').checked = cfg.includeAlreadyFollowing;
-  qs('#modeFollow').checked = cfg.actionModeDefault === 'follow';
-  qs('#modeFollowLike').checked = cfg.actionModeDefault === 'follow_like';
-  qs('#modeUnfollow').checked = cfg.actionModeDefault === 'unfollow';
+  qs("#likeCount").value = String(cfg.likePerProfile);
+  qs("#cfgPageSize").value = cfg.pageSize;
+  qs("#pageSize").value = String(cfg.pageSize);
+  qs("#cfgDelayMs").value = cfg.baseDelayMs / 1000;
+  qs("#cfgJitterPct").value = cfg.jitterPct;
+  qs("#cfgLikePerProfile").value = cfg.likePerProfile;
+  qs("#cfgMode").value = cfg.actionModeDefault;
+  qs("#cfgIncludeAlreadyFollowing").checked = cfg.includeAlreadyFollowing;
+  qs("#modeFollow").checked = cfg.actionModeDefault === "follow";
+  qs("#modeFollowLike").checked = cfg.actionModeDefault === "follow_like";
+  qs("#modeUnfollow").checked = cfg.actionModeDefault === "unfollow";
   pageSize = cfg.pageSize;
   renderTable();
   updatePager();
@@ -403,18 +420,18 @@ function saveCfgFromInputs() {
 function loadCfg() {
   chrome.storage.local.get(DEFAULT_CFG, (st) => {
     cfg = { ...DEFAULT_CFG, ...st };
-    qs('#cfgDelayMs').value = cfg.baseDelayMs / 1000;
-    qs('#cfgJitterPct').value = cfg.jitterPct;
-    qs('#cfgPageSize').value = cfg.pageSize;
-    qs('#cfgLikePerProfile').value = cfg.likePerProfile;
-    qs('#cfgMode').value = cfg.actionModeDefault;
-    qs('#cfgIncludeAlreadyFollowing').checked = cfg.includeAlreadyFollowing;
-    qs('#likeCount').value = cfg.likePerProfile;
-    qs('#modeFollow').checked = cfg.actionModeDefault === 'follow';
-    qs('#modeFollowLike').checked = cfg.actionModeDefault === 'follow_like';
-    qs('#modeUnfollow').checked = cfg.actionModeDefault === 'unfollow';
+    qs("#cfgDelayMs").value = cfg.baseDelayMs / 1000;
+    qs("#cfgJitterPct").value = cfg.jitterPct;
+    qs("#cfgPageSize").value = cfg.pageSize;
+    qs("#cfgLikePerProfile").value = cfg.likePerProfile;
+    qs("#cfgMode").value = cfg.actionModeDefault;
+    qs("#cfgIncludeAlreadyFollowing").checked = cfg.includeAlreadyFollowing;
+    qs("#likeCount").value = cfg.likePerProfile;
+    qs("#modeFollow").checked = cfg.actionModeDefault === "follow";
+    qs("#modeFollowLike").checked = cfg.actionModeDefault === "follow_like";
+    qs("#modeUnfollow").checked = cfg.actionModeDefault === "unfollow";
     pageSize = cfg.pageSize;
-    qs('#pageSize').value = String(pageSize);
+    qs("#pageSize").value = String(pageSize);
     handleLikeInput();
     renderTable();
     updatePager();
@@ -423,5 +440,5 @@ function loadCfg() {
 
 function saveCfg() {
   chrome.storage.local.set(cfg);
-  chrome.runtime.sendMessage({ type: 'CFG_UPDATED', cfg });
+  chrome.runtime.sendMessage({ type: "CFG_UPDATED", cfg });
 }


### PR DESCRIPTION
## Summary
- Validate and log delay calculations with `[sched]` messages
- Add `enterBackoff` and robust `scheduleNext` to always set alarms
- Rehydrate and watchdog now repair missing alarms and resume work
- Treat idle phase in panel overlay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8a78dc2c083268736e8a0c12f41f0