### PR TITLE
Handle following list type without already-following filter

### DIFF
--- a/background.js
+++ b/background.js
@@ -619,7 +619,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   } else if (msg.type === "START_QUEUE") {
     if (q.isRunning)
       return sendResponse({ ok: false, error: "already_running" });
-    const { mode, likeCount, targets, cfg } = msg;
+    const { mode, likeCount, targets, cfg, listType } = msg;
     if (!["follow", "follow_like", "unfollow"].includes(mode))
       return sendResponse({ ok: false, error: "invalid_mode" });
     if (!Array.isArray(targets) || !targets.length)
@@ -628,7 +628,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       q.tabId = tabs[0]?.id || null;
       if (!q.tabId) return sendResponse({ ok: false, error: "no_tab" });
       let items = targets.slice();
-      if (!cfg?.includeAlreadyFollowing) {
+      if (!cfg?.includeAlreadyFollowing && listType !== "following") {
         const pre = await precheckWindow(q.tabId, items);
         items = pre.items;
       }
@@ -643,7 +643,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       q.likeCount = likeCount || 0;
       q.cfg = sanitizeConfig({ ...DEFAULT_CFG, ...(cfg || {}) });
       backoffStep = 0;
-      log("start", q.total, mode);
+      log("start", q.total, mode, listType);
       chrome.alarms.clear(ALARM_WATCHDOG);
       chrome.alarms.create(ALARM_WATCHDOG, { when: Date.now() + 10_000 });
       scheduleNext(0);

--- a/panel.html
+++ b/panel.html
@@ -26,6 +26,7 @@
         </div>
       </div>
       <label id="limitLabel">Limite: <input id="limit" type="number" min="0" max="200" value="200" /></label>
+      <span id="listOrigin"></span>
       <span id="collectProgress"></span>
     </div>
     <div id="queueContainer" class="card">

--- a/panel.js
+++ b/panel.js
@@ -8,6 +8,7 @@ const DEFAULT_CFG = {
 };
 let cfg = { ...DEFAULT_CFG };
 let followers = [];
+let listType = "followers";
 let page = 1;
 let pageSize = DEFAULT_CFG.pageSize;
 let running = false;
@@ -45,12 +46,16 @@ window.__IG_PANEL_MSG_HANDLER = (ev) => {
       return;
     }
     followers = msg.items || [];
+    listType = msg.listType || "followers";
     page = 1;
     totalRemovedAlreadyFollowing = msg.removedAlreadyFollowing || 0;
     totalUnknown = msg.unknownTotal || 0;
     renderTable();
     updatePager();
     updateCollectProgress();
+    const originLabel =
+      listType === "following" ? "Seguindo" : "Seguidores";
+    qs("#listOrigin").textContent = `Origem: ${originLabel}`;
   } else if (msg.type === "ROW_UPDATE") {
     const row = followers.find((f) => f.id === msg.id);
     if (row) {
@@ -107,6 +112,7 @@ window.__IG_PANEL_MSG_HANDLER = (ev) => {
     running = false;
     followers = [];
     page = 1;
+    listType = "followers";
     totalRemovedAlreadyFollowing = 0;
     totalUnknown = 0;
     ov = {
@@ -123,6 +129,7 @@ window.__IG_PANEL_MSG_HANDLER = (ev) => {
     renderTable();
     updatePager();
     updateCollectProgress();
+    qs("#listOrigin").textContent = "";
     updateRunButtons();
   }
 };
@@ -252,7 +259,14 @@ function startProcessing() {
   const mode = document.querySelector('input[name="actionMode"]:checked').value;
   const likeCount = parseInt(qs("#likeCount").value, 10) || 0;
   const cfgSnapshot = getCurrentCfg();
-  send({ type: "START_QUEUE", mode, likeCount, targets, cfg: cfgSnapshot });
+  send({
+    type: "START_QUEUE",
+    mode,
+    likeCount,
+    targets,
+    cfg: cfgSnapshot,
+    listType,
+  });
   running = true;
   updateRunButtons();
 }


### PR DESCRIPTION
## Summary
- propagate listType through collection and queue start
- allow 'following' list to skip already-following filtering while preserving dedup/order
- surface list origin in panel for debugging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb3af89dc88326935cfdaf058b9f0e