### PR TITLE
Show neutral badge for unfollow actions

### DIFF
--- a/panel.css
+++ b/panel.css
@@ -114,6 +114,10 @@ button:disabled {
   background: #95a5a6;
   color: #fff;
 }
+.badge.neutral {
+  background: #3498db;
+  color: #fff;
+}
 #collectProgress {
   margin-left: 8px;
 }

--- a/panel.js
+++ b/panel.js
@@ -330,8 +330,10 @@ function renderStatus(f) {
   if (st.error) return `<span class="badge error">${st.error}</span>`;
   if (st.likesTotal)
     return `<span class="badge wait">Likes: ${st.likesDone || 0}/${st.likesTotal}</span>`;
-  if (st.followed || st.unfollowed)
+  if (st.followed)
     return '<span class="badge success">Seguido</span>';
+  if (st.unfollowed)
+    return '<span class="badge neutral">done</span>';
   return "";
 }
 


### PR DESCRIPTION
## Summary
- distinguish follow vs unfollow completion in the panel
- add neutral badge style for finished unfollow operations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb3d8dc0fc8326b83c8f54a455cf99